### PR TITLE
feat: support calling permissions function multiple time

### DIFF
--- a/src/documentBuilder.spec.ts
+++ b/src/documentBuilder.spec.ts
@@ -2,7 +2,6 @@ import {DocumentBuilder} from './documentBuilder';
 import {
   GroupSecurityIdentityBuilder,
   UserSecurityIdentityBuilder,
-  VirtualGroupSecurityIdentityBuilder,
 } from './securityIdentityBuilder';
 
 describe('DocumentBuilder', () => {

--- a/src/documentBuilder.spec.ts
+++ b/src/documentBuilder.spec.ts
@@ -1,5 +1,9 @@
 import {DocumentBuilder} from './documentBuilder';
-import {UserSecurityIdentityBuilder} from './securityIdentityBuilder';
+import {
+  GroupSecurityIdentityBuilder,
+  UserSecurityIdentityBuilder,
+  VirtualGroupSecurityIdentityBuilder,
+} from './securityIdentityBuilder';
 
 describe('DocumentBuilder', () => {
   let docBuilder: DocumentBuilder;
@@ -109,6 +113,26 @@ describe('DocumentBuilder', () => {
     });
   });
 
+  it('should marshal allowedPermissions in multiple #withAllowedPermissions', () => {
+    expect(
+      docBuilder
+        .withAllowedPermissions(new UserSecurityIdentityBuilder('bob@foo.com'))
+        .withAllowedPermissions(new GroupSecurityIdentityBuilder('my_group'))
+        .marshal().permissions![0]
+    ).toMatchObject({
+      allowedPermissions: expect.arrayContaining([
+        expect.objectContaining({
+          identity: 'bob@foo.com',
+          identityType: 'USER',
+        }),
+        expect.objectContaining({
+          identity: 'my_group',
+          identityType: 'GROUP',
+        }),
+      ]),
+    });
+  });
+
   it('should marshal multiple allowedPermissions', () => {
     expect(
       docBuilder
@@ -132,6 +156,26 @@ describe('DocumentBuilder', () => {
     ).toMatchObject({
       deniedPermissions: expect.arrayContaining([
         expect.objectContaining({identity: 'bob@foo.com'}),
+      ]),
+    });
+  });
+
+  it('should marshal deniedPermissions in multiple #withDeniedPermissions', () => {
+    expect(
+      docBuilder
+        .withDeniedPermissions(new UserSecurityIdentityBuilder('bob@foo.com'))
+        .withDeniedPermissions(new GroupSecurityIdentityBuilder('my_group'))
+        .marshal().permissions![0]
+    ).toMatchObject({
+      deniedPermissions: expect.arrayContaining([
+        expect.objectContaining({
+          identity: 'bob@foo.com',
+          identityType: 'USER',
+        }),
+        expect.objectContaining({
+          identity: 'my_group',
+          identityType: 'GROUP',
+        }),
       ]),
     });
   });

--- a/src/documentBuilder.ts
+++ b/src/documentBuilder.ts
@@ -288,10 +288,15 @@ export class DocumentBuilder {
     permissionSection: 'allowedPermissions' | 'deniedPermissions'
   ) {
     const identities = securityIdentityBuilder.build();
+    if (!this.doc.permissions![permissionSection]) {
+      this.doc.permissions![permissionSection] = [];
+    }
     if (Array.isArray(identities)) {
-      this.doc.permissions![permissionSection] = identities;
+      this.doc.permissions![permissionSection] = this.doc.permissions![
+        permissionSection
+      ]?.concat(identities);
     } else {
-      this.doc.permissions![permissionSection] = [identities];
+      this.doc.permissions![permissionSection]?.push(identities);
     }
   }
 }


### PR DESCRIPTION
Previously, calling `withAllowedPermissions` and `withDeniedPermissions` would replace the previous permission set, instead of adding/concatenating.

This will be useful for CLI push commands, among others.

https://coveord.atlassian.net/browse/CDX-486