### PR TITLE
feat(permanentid): replace sha256 by md5(30)+sha1(30)

### DIFF
--- a/src/documentBuilder.spec.ts
+++ b/src/documentBuilder.spec.ts
@@ -81,6 +81,13 @@ describe('DocumentBuilder', () => {
     expect(docBuilder.withPermanentId('id').marshal().permanentId).toBe('id');
   });
 
+  it('should generate permanentid', () => {
+    docBuilder = new DocumentBuilder('https://foo.com', 'bar');
+    expect(docBuilder.marshal().permanentId).toBe(
+      'aa2e0510b66edff7f05e2b30d4f1b3a4b5481c06b69f41751c54675c5afb'
+    );
+  });
+
   it('throws when adding a reserved key name metadata', () => {
     const theseShouldThrow = [
       'compressedBinaryData',

--- a/src/documentBuilder.ts
+++ b/src/documentBuilder.ts
@@ -268,7 +268,9 @@ export class DocumentBuilder {
   }
 
   private generatePermanentId() {
-    return createHash('sha256').update(this.doc.uri).digest('hex');
+    const md5: string = createHash('md5').update(this.doc.uri).digest('hex');
+    const sha1: string = createHash('sha1').update(this.doc.uri).digest('hex');
+    return md5.substring(0, 30) + sha1.substring(0, 30);
   }
 
   private validateDateAndReturnValidDate(d: Date | string | number) {


### PR DESCRIPTION
The limit for `permanentid` in the index is actually 60 characters. hashlib.sha256() is generating a 64-character hash. 

Rather than simply truncating it, I am proposing the default algorithm to generate permanentid in the index: `md5[:30]+sha1[:30]`