### PR TITLE
feat: support different regions

### DIFF
--- a/src/environment.ts
+++ b/src/environment.ts
@@ -1,0 +1,49 @@
+import {Region, Environment} from '@coveord/platform-client';
+export {Region} from '@coveord/platform-client';
+
+export enum PlatformEnvironment {
+  Dev = 'dev',
+  QA = 'qa',
+  Hipaa = 'hipaa',
+  Prod = 'prod',
+}
+
+export const DEFAULT_ENVIRONMENT = PlatformEnvironment.Prod as const;
+export const DEFAULT_REGION = Region.US as const;
+
+export type PlatformUrlOptions = {
+  environment: PlatformEnvironment;
+  region: Region;
+};
+
+const defaultOptions: PlatformUrlOptions = {
+  environment: DEFAULT_ENVIRONMENT,
+  region: DEFAULT_REGION,
+};
+
+export function platformUrl(options?: Partial<PlatformUrlOptions>) {
+  options = {...defaultOptions, ...options};
+  const urlEnv =
+    options.environment === DEFAULT_ENVIRONMENT ? '' : options.environment;
+  const urlRegion =
+    options.region === DEFAULT_REGION ? '' : `-${options.region}`;
+
+  return `https://api${urlEnv}${urlRegion}.cloud.coveo.com/push/v1/organizations`;
+}
+
+export function castEnvironmentToPlatformClient(
+  e: PlatformEnvironment
+): Environment {
+  switch (e) {
+    case 'dev':
+      return Environment.dev;
+    case 'qa':
+      return Environment.staging;
+    case 'prod':
+      return Environment.prod;
+    case 'hipaa':
+      return Environment.hipaa;
+    default:
+      return Environment.prod;
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,6 @@
 export * from './document';
 export {
   Source,
-  Environment,
   SourceVisibility,
   BatchUpdateDocuments,
   UploadBatchCallback,
@@ -10,3 +9,4 @@ export {
 } from './source';
 export {DocumentBuilder} from './documentBuilder';
 export * from './securityIdentityBuilder';
+export {PlatformEnvironment, Region} from './environment';

--- a/src/source.spec.ts
+++ b/src/source.spec.ts
@@ -1,7 +1,10 @@
 /* eslint-disable node/no-unpublished-import */
 jest.mock('@coveord/platform-client');
 jest.mock('axios');
-import PlatformClient, {SourceVisibility} from '@coveord/platform-client';
+import PlatformClient, {
+  Region,
+  SourceVisibility,
+} from '@coveord/platform-client';
 import {BatchUpdateDocuments, Source} from './source';
 import {DocumentBuilder} from './documentBuilder';
 import axios from 'axios';
@@ -54,6 +57,22 @@ describe('Source', () => {
 
     expect(mockAxios.put).toHaveBeenCalledWith(
       'https://api.cloud.coveo.com/push/v1/organizations/the_org/sources/the_id/documents?documentId=the_uri',
+      expect.objectContaining({title: 'the_title'}),
+      expectedDocumentsHeaders
+    );
+  });
+
+  it('should call axios on add document with right region', () => {
+    const australianSource = new Source('the_key', 'the_org', {
+      region: Region.AU,
+    });
+    australianSource.addOrUpdateDocument(
+      'the_id',
+      new DocumentBuilder('the_uri', 'the_title')
+    );
+
+    expect(mockAxios.put).toHaveBeenCalledWith(
+      'https://api-au.cloud.coveo.com/push/v1/organizations/the_org/sources/the_id/documents?documentId=the_uri',
       expect.objectContaining({title: 'the_title'}),
       expectedDocumentsHeaders
     );

--- a/src/source.spec.ts
+++ b/src/source.spec.ts
@@ -90,6 +90,7 @@ describe('Source', () => {
       expectedDocumentsHeaders
     );
   });
+
   it('should call axios on add document with right region and environment', () => {
     new Source('the_key', 'the_org', {
       environment: PlatformEnvironment.QA,

--- a/src/source.spec.ts
+++ b/src/source.spec.ts
@@ -1,15 +1,13 @@
 /* eslint-disable node/no-unpublished-import */
 jest.mock('@coveord/platform-client');
 jest.mock('axios');
-import PlatformClient, {
-  Region,
-  SourceVisibility,
-} from '@coveord/platform-client';
+import PlatformClient, {SourceVisibility} from '@coveord/platform-client';
 import {BatchUpdateDocuments, Source} from './source';
 import {DocumentBuilder} from './documentBuilder';
 import axios from 'axios';
 import {join} from 'path';
 import {cwd} from 'process';
+import {PlatformEnvironment, Region} from '.';
 const mockAxios = axios as jest.Mocked<typeof axios>;
 
 const mockedPlatformClient = jest.mocked(PlatformClient);
@@ -73,6 +71,36 @@ describe('Source', () => {
 
     expect(mockAxios.put).toHaveBeenCalledWith(
       'https://api-au.cloud.coveo.com/push/v1/organizations/the_org/sources/the_id/documents?documentId=the_uri',
+      expect.objectContaining({title: 'the_title'}),
+      expectedDocumentsHeaders
+    );
+  });
+
+  it('should call axios on add document with right environment', () => {
+    new Source('the_key', 'the_org', {
+      environment: PlatformEnvironment.Dev,
+    }).addOrUpdateDocument(
+      'the_id',
+      new DocumentBuilder('the_uri', 'the_title')
+    );
+
+    expect(mockAxios.put).toHaveBeenCalledWith(
+      'https://apidev.cloud.coveo.com/push/v1/organizations/the_org/sources/the_id/documents?documentId=the_uri',
+      expect.objectContaining({title: 'the_title'}),
+      expectedDocumentsHeaders
+    );
+  });
+  it('should call axios on add document with right region and environment', () => {
+    new Source('the_key', 'the_org', {
+      environment: PlatformEnvironment.QA,
+      region: Region.EU,
+    }).addOrUpdateDocument(
+      'the_id',
+      new DocumentBuilder('the_uri', 'the_title')
+    );
+
+    expect(mockAxios.put).toHaveBeenCalledWith(
+      'https://apiqa-eu.cloud.coveo.com/push/v1/organizations/the_org/sources/the_id/documents?documentId=the_uri',
       expect.objectContaining({title: 'the_title'}),
       expectedDocumentsHeaders
     );


### PR DESCRIPTION
This PR adds an option to specify the region when creating the source instance.
If not specified, the US region will be selected.

Following the issue: #87 