### PR TITLE
feat: add `FieldAnalyser` class

### DIFF
--- a/src/fieldAnalyser/fieldAnalyser.ts
+++ b/src/fieldAnalyser/fieldAnalyser.ts
@@ -5,7 +5,7 @@ type fieldTypeDict = {[key in FieldTypes]?: number};
 type typeOccurence = [fieldType: string, occurence: number];
 export class FieldAnalyser {
   private static fieldTypePrecedence = ['DOUBLE', 'STRING'];
-  private inconsitentFields: Record<string, FieldTypes[]> = {};
+  private inconsistentFields: Record<string, FieldTypes[]> = {};
 
   public constructor(private platformClient: PlatformClient) {}
   public async createMissingFieldsFromBatch(batch: BatchUpdateDocuments) {
@@ -43,7 +43,7 @@ export class FieldAnalyser {
         }
         const metadataType = this.getValue(metadataValue);
         if (missingFieldsFromOrg[metadataKey]) {
-          // Possible metadata inconsitency
+          // Possible metadata inconsistency
           let fieldType = missingFieldsFromOrg[metadataKey][metadataType];
           missingFieldsFromOrg[metadataKey][metadataType] = fieldType
             ? ++fieldType
@@ -79,7 +79,7 @@ export class FieldAnalyser {
   ) {
     const typePossibilities = Object.keys(fieldTypeDict) as FieldTypes[];
     if (typePossibilities.length > 1) {
-      this.inconsitentFields[fieldName] = typePossibilities;
+      this.inconsistentFields[fieldName] = typePossibilities;
     }
   }
 
@@ -125,7 +125,7 @@ export class FieldAnalyser {
   }
 
   private warnAboutInconsistentFields() {
-    Object.entries(this.inconsitentFields).map(([fieldName, types]) => {
+    Object.entries(this.inconsistentFields).map(([fieldName, types]) => {
       console.log(
         `Inconsistency detected with the metadata "${fieldName}". Possible types are: ${types
           .sort()

--- a/src/fieldAnalyser/fieldAnalyser.ts
+++ b/src/fieldAnalyser/fieldAnalyser.ts
@@ -1,0 +1,138 @@
+import PlatformClient, {FieldTypes} from '@coveord/platform-client';
+import {BatchUpdateDocuments, DocumentBuilder} from '..';
+
+type fieldTypeDict = {[key in FieldTypes]?: number};
+type typeOccurence = [fieldType: string, occurence: number];
+export class FieldAnalyser {
+  private static fieldTypePrecedence = ['DOUBLE', 'STRING'];
+  private inconsitentFields: Record<string, FieldTypes[]> = {};
+
+  public constructor(private platformClient: PlatformClient) {}
+  public async createMissingFieldsFromBatch(batch: BatchUpdateDocuments) {
+    const alreadyCreatedFields = await this.listAllFieldsFromOrg();
+    const missingFieldsFromOrg = this.getMissingFieldsFromOrg(
+      batch,
+      alreadyCreatedFields
+    );
+    const fieldsToCreate = this.getFieldsToCreate(missingFieldsFromOrg);
+    return this.createFields(fieldsToCreate);
+  }
+
+  private async listAllFieldsFromOrg(): Promise<string[]> {
+    // TODO: CDX-836
+    throw new Error('Method not implemented.');
+  }
+
+  private createFields(_fields: Record<string, FieldTypes>) {
+    // TODO: CDX-835
+    throw new Error('Method not implemented.');
+  }
+
+  private getMissingFieldsFromOrg(
+    batch: BatchUpdateDocuments,
+    alreadyCreatedFields: string[]
+  ): Record<string, fieldTypeDict> {
+    const missingFieldsFromOrg: Record<string, fieldTypeDict> = {};
+
+    batch.addOrUpdate.flatMap((doc: DocumentBuilder) => {
+      const documentMetadata = Object.entries({...doc.build().metadata});
+
+      for (const [metadataKey, metadataValue] of documentMetadata) {
+        if (alreadyCreatedFields.includes(metadataKey)) {
+          continue;
+        }
+        const metadataType = this.getValue(metadataValue);
+        if (missingFieldsFromOrg[metadataKey]) {
+          // Possible metadata inconsitency
+          let fieldType = missingFieldsFromOrg[metadataKey][metadataType];
+          missingFieldsFromOrg[metadataKey][metadataType] = fieldType
+            ? ++fieldType
+            : 1;
+        } else {
+          missingFieldsFromOrg[metadataKey] = {[metadataType]: 1};
+        }
+      }
+    });
+
+    return missingFieldsFromOrg;
+  }
+
+  private getFieldsToCreate(
+    missingFieldsFromOrg: Record<string, fieldTypeDict>
+  ): Record<string, FieldTypes> {
+    const fieldsToCreate: Record<string, FieldTypes> = {};
+
+    Object.entries(missingFieldsFromOrg).map(([fieldName, fieldTypeDict]) => {
+      this.storePossibleTypeInconsistencies(fieldName, fieldTypeDict);
+      const fieldType = this.getMostProbableType(fieldTypeDict);
+      fieldsToCreate[fieldName] = fieldType;
+    });
+
+    this.warnAboutInconsistentFields();
+
+    return fieldsToCreate;
+  }
+
+  private storePossibleTypeInconsistencies(
+    fieldName: string,
+    fieldTypeDict: fieldTypeDict
+  ) {
+    const typePossibilities = Object.keys(fieldTypeDict) as FieldTypes[];
+    if (typePossibilities.length > 1) {
+      this.inconsitentFields[fieldName] = typePossibilities;
+    }
+  }
+
+  private getMostProbableType(field: fieldTypeDict): FieldTypes {
+    const [fieldType] = Object.entries(field).reduce((previous, current) => {
+      if (current[1] > previous[1]) {
+        return current;
+      } else if (current[1] < previous[1]) {
+        return previous;
+      } else {
+        return [current, previous].sort(this.typeCompare)[0];
+      }
+    });
+    return fieldType as FieldTypes;
+  }
+
+  private typeCompare(field1: typeOccurence, field2: typeOccurence): number {
+    const precedence = (field: typeOccurence) =>
+      FieldAnalyser.fieldTypePrecedence.indexOf(field[0]);
+    if (precedence(field1) < precedence(field2)) {
+      return 1;
+    }
+    if (precedence(field1) > precedence(field2)) {
+      return -1;
+    }
+    return 0;
+  }
+
+  private getValue(obj: unknown): FieldTypes {
+    switch (typeof obj) {
+      case 'number':
+        return this.getSpecificNumericType(obj);
+      case 'string':
+        return FieldTypes.STRING;
+      default:
+        return FieldTypes.STRING;
+    }
+  }
+
+  private getSpecificNumericType(_number: number): FieldTypes {
+    // TODO: CDX-838 Support LONG, LONG32 and DATE types
+    return FieldTypes.DOUBLE;
+  }
+
+  private warnAboutInconsistentFields() {
+    Object.entries(this.inconsitentFields).map(([fieldName, types]) => {
+      console.log(
+        `Inconsistency detected with the metadata "${fieldName}". Possible types are: ${types
+          .sort()
+          .join(', ')}`
+      );
+    });
+
+    // TODO: CDX-836: Request user intervention during field type inconsistency
+  }
+}

--- a/src/source.ts
+++ b/src/source.ts
@@ -219,6 +219,7 @@ export class Source {
     sourceID: string,
     batch: BatchUpdateDocuments
   ) {
+    // TODO: CDX-840 Include FieldAnalyser in source class
     const fileContainer = await this.createFileContainer();
     await this.uploadContentToFileContainer(fileContainer, batch);
     return this.pushFileContainerContent(sourceID, fileContainer);
@@ -238,6 +239,7 @@ export class Source {
     callback: UploadBatchCallback,
     {maxConcurrent = 10}: BatchUpdateDocumentsFromFiles = {}
   ) {
+    // TODO: CDX-840 Include FieldAnalyser in source class
     const files = getAllJsonFilesFromEntries(filesOrDirectories);
     const fileNames = files.map((path) => basename(path));
     const {chunksToUpload, close} = this.splitByChunkAndUpload(


### PR DESCRIPTION
Adding a "Field Analyser" module right before initiating the push.
This module will be responsible of creating the missing fields with the right type, but also detecting type inconsistencies across batch(es) to be sent.
If type inconsistencies are detected, a prompt or any other process requiring user intervention will be put in place... or a flag allowing the SDK to choose the most probable type based on the documents.
