### PR TITLE
BREAKING CHANGE: encapsulate security identity

### DIFF
--- a/src/environment.ts
+++ b/src/environment.ts
@@ -12,8 +12,8 @@ export const DEFAULT_ENVIRONMENT = PlatformEnvironment.Prod as const;
 export const DEFAULT_REGION = Region.US as const;
 
 export type PlatformUrlOptions = {
-  environment: PlatformEnvironment;
-  region: Region;
+  environment?: PlatformEnvironment;
+  region?: Region;
 };
 
 const defaultOptions: PlatformUrlOptions = {
@@ -21,7 +21,7 @@ const defaultOptions: PlatformUrlOptions = {
   region: DEFAULT_REGION,
 };
 
-export function platformUrl(options?: Partial<PlatformUrlOptions>) {
+export function platformUrl(options?: PlatformUrlOptions) {
   options = {...defaultOptions, ...options};
   const urlEnv =
     options.environment === DEFAULT_ENVIRONMENT ? '' : options.environment;

--- a/src/source.ts
+++ b/src/source.ts
@@ -30,6 +30,7 @@ import {
 import {FieldAnalyser} from './fieldAnalyser/fieldAnalyser';
 import {FieldTypeInconsistencyError} from './errors/fieldErrors';
 import {createFields} from './fieldAnalyser/fieldUtils';
+import {SecurityIdentity} from './source/securityIdenty';
 
 export type SourceStatus = 'REBUILD' | 'REFRESH' | 'INCREMENTAL' | 'IDLE';
 
@@ -126,81 +127,8 @@ export class Source {
     });
   }
 
-  /**
-   * Create or update a security identity. See [Adding a Single Security Identity](https://docs.coveo.com/en/167) and [Security Identity Models](https://docs.coveo.com/en/139).
-   * @param securityProviderId
-   * @param securityIdentity
-   * @returns
-   */
-  public createSecurityIdentity(
-    securityProviderId: string,
-    securityIdentity: SecurityIdentityModel
-  ) {
-    return this.platformClient.pushApi.createOrUpdateSecurityIdentity(
-      securityProviderId,
-      securityIdentity
-    );
-  }
-
-  /**
-   * Create or update a security identity alias. See [Adding a Single Alias](https://docs.coveo.com/en/142) and [User Alias Definition Examples](https://docs.coveo.com/en/46).
-   * @param securityProviderId
-   * @param securityIdentityAlias
-   * @returns
-   */
-  public createOrUpdateSecurityIdentityAlias(
-    securityProviderId: string,
-    securityIdentityAlias: SecurityIdentityAliasModel
-  ) {
-    return this.platformClient.pushApi.createOrUpdateSecurityIdentityAlias(
-      securityProviderId,
-      securityIdentityAlias
-    );
-  }
-
-  /**
-   * Delete a security identity. See [Disabling a Single Security Identity](https://docs.coveo.com/en/84).
-   * @param securityProviderId
-   * @param securityIdentityToDelete
-   * @returns
-   */
-  public deleteSecurityIdentity(
-    securityProviderId: string,
-    securityIdentityToDelete: SecurityIdentityDelete
-  ) {
-    return this.platformClient.pushApi.deleteSecurityIdentity(
-      securityProviderId,
-      securityIdentityToDelete
-    );
-  }
-
-  /**
-   * Delete old security identities. See [Disabling Old Security Identities](https://docs.coveo.com/en/33).
-   * @param securityProviderId
-   * @param batchDelete
-   * @returns
-   */
-  public deleteOldSecurityIdentities(
-    securityProviderId: string,
-    batchDelete: SecurityIdentityDeleteOptions
-  ) {
-    return this.platformClient.pushApi.deleteOldSecurityIdentities(
-      securityProviderId,
-      batchDelete
-    );
-  }
-
-  /**
-   * Manage batches of security identities. See [Manage Batches of Security Identities](https://docs.coveo.com/en/55).
-   */
-  public manageSecurityIdentities(
-    securityProviderId: string,
-    batchConfig: SecurityIdentityBatchConfig
-  ) {
-    return this.platformClient.pushApi.manageSecurityIdentities(
-      securityProviderId,
-      batchConfig
-    );
+  public get identity() {
+    return new SecurityIdentity(this.platformClient);
   }
 
   /**

--- a/src/source.ts
+++ b/src/source.ts
@@ -86,8 +86,8 @@ interface FileContainerResponse {
  */
 export class Source {
   private platformClient: PlatformClient;
-  private options: PlatformUrlOptions;
-  private static defaultOptions: PlatformUrlOptions = {
+  private options: Required<PlatformUrlOptions>;
+  private static defaultOptions: Required<PlatformUrlOptions> = {
     region: DEFAULT_REGION,
     environment: DEFAULT_ENVIRONMENT,
   };
@@ -100,7 +100,7 @@ export class Source {
   constructor(
     private apikey: string,
     private organizationid: string,
-    options?: Partial<PlatformUrlOptions>
+    options?: PlatformUrlOptions
   ) {
     this.options = {...Source.defaultOptions, ...options};
     this.platformClient = new PlatformClient({

--- a/src/source/securityIdenty.ts
+++ b/src/source/securityIdenty.ts
@@ -1,0 +1,97 @@
+require('isomorphic-fetch');
+require('abortcontroller-polyfill');
+
+import {
+  PlatformClient,
+  SecurityIdentityAliasModel,
+  SecurityIdentityBatchConfig,
+  SecurityIdentityDelete,
+  SecurityIdentityDeleteOptions,
+  SecurityIdentityModel,
+} from '@coveord/platform-client';
+
+export class SecurityIdentity {
+  /**
+   *
+   * @param apikey An apiKey capable of pushing documents and managing sources in a Coveo organization. See [Manage API Keys](https://docs.coveo.com/en/1718).
+   * @param organizationid The Coveo Organization identifier.
+   */
+  constructor(private platformClient: PlatformClient) {}
+
+  /**
+   * Create or update a security identity. See [Adding a Single Security Identity](https://docs.coveo.com/en/167) and [Security Identity Models](https://docs.coveo.com/en/139).
+   * @param securityProviderId
+   * @param securityIdentity
+   * @returns
+   */
+  public createSecurityIdentity(
+    securityProviderId: string,
+    securityIdentity: SecurityIdentityModel
+  ) {
+    return this.platformClient.pushApi.createOrUpdateSecurityIdentity(
+      securityProviderId,
+      securityIdentity
+    );
+  }
+
+  /**
+   * Create or update a security identity alias. See [Adding a Single Alias](https://docs.coveo.com/en/142) and [User Alias Definition Examples](https://docs.coveo.com/en/46).
+   * @param securityProviderId
+   * @param securityIdentityAlias
+   * @returns
+   */
+  public createOrUpdateSecurityIdentityAlias(
+    securityProviderId: string,
+    securityIdentityAlias: SecurityIdentityAliasModel
+  ) {
+    return this.platformClient.pushApi.createOrUpdateSecurityIdentityAlias(
+      securityProviderId,
+      securityIdentityAlias
+    );
+  }
+
+  /**
+   * Delete a security identity. See [Disabling a Single Security Identity](https://docs.coveo.com/en/84).
+   * @param securityProviderId
+   * @param securityIdentityToDelete
+   * @returns
+   */
+  public deleteSecurityIdentity(
+    securityProviderId: string,
+    securityIdentityToDelete: SecurityIdentityDelete
+  ) {
+    return this.platformClient.pushApi.deleteSecurityIdentity(
+      securityProviderId,
+      securityIdentityToDelete
+    );
+  }
+
+  /**
+   * Delete old security identities. See [Disabling Old Security Identities](https://docs.coveo.com/en/33).
+   * @param securityProviderId
+   * @param batchDelete
+   * @returns
+   */
+  public deleteOldSecurityIdentities(
+    securityProviderId: string,
+    batchDelete: SecurityIdentityDeleteOptions
+  ) {
+    return this.platformClient.pushApi.deleteOldSecurityIdentities(
+      securityProviderId,
+      batchDelete
+    );
+  }
+
+  /**
+   * Manage batches of security identities. See [Manage Batches of Security Identities](https://docs.coveo.com/en/55).
+   */
+  public manageSecurityIdentities(
+    securityProviderId: string,
+    batchConfig: SecurityIdentityBatchConfig
+  ) {
+    return this.platformClient.pushApi.manageSecurityIdentities(
+      securityProviderId,
+      batchConfig
+    );
+  }
+}


### PR DESCRIPTION
<!-- For Coveo Employees only. Fill this section.

CDX-XXX

-->

## Proposed changes

Since multiple sources can benefits from the same security identity methods, I moved them into a dedicated class.
The Security Identity class can now easily be composed in any other class.

## Breaking changes
Every methods regarding the security identity management will be under `source.identity`. Since different sources (push and eventually catalog) are basically following the same logic to set security identity it would make sense to move that piece into a separate file.

Eventually, both Push and Catalog sources will be using the SecurityIdentity class.

Also, since the security identity methods would probably be used less than the methods to upload data, the interface would be cleaner that way
![image](https://user-images.githubusercontent.com/12199712/158890525-b7604196-a472-460a-a963-78809b363f47.png)

before
`source.createSecurityIdentity(...)`
now
`source.identity.createSecurityIdentity(...)`


## Testing

- [ ] Unit Tests:
<!-- Did you write unit tests for your feature? If not, explains why?  -->
- [ ] Functionnal Tests:
<!-- Did you write functionnal tests for your feature? If not, explains why?  -->
- [ ] Manual Tests:
<!-- How did you test your changeset?  -->
