### PR TITLE
feat: provide better info on missing API key privileges

### DIFF
--- a/src/errors/privilegeError.ts
+++ b/src/errors/privilegeError.ts
@@ -1,0 +1,8 @@
+import {PushApiClientBaseError} from './baseError';
+
+export class PrivilegeError extends PushApiClientBaseError {
+  public name = 'Privilege Error';
+  public constructor(public message: string) {
+    super(message);
+  }
+}

--- a/src/fieldAnalyser/fieldAnalyser.ts
+++ b/src/fieldAnalyser/fieldAnalyser.ts
@@ -5,6 +5,8 @@ import {FieldStore} from './fieldStore';
 import {Inconsistencies} from './inconsistencies';
 import {InvalidPermanentId} from '../errors/fieldErrors';
 import {getGuessedTypeFromValue, isValidTypeTransition} from './typeUtils';
+import {ensureNecessaryCoveoPrivileges} from '../validation/preconditions/apiKeyPrivilege';
+import {writeFieldsPrivilege} from '../validation/preconditions/platformPrivilege';
 
 export type FieldAnalyserReport = {
   fields: FieldModel[];
@@ -33,6 +35,10 @@ export class FieldAnalyser {
    * @return {*}
    */
   public async add(batch: DocumentBuilder[]) {
+    await ensureNecessaryCoveoPrivileges(
+      this.platformClient,
+      writeFieldsPrivilege
+    );
     const existingFields = await this.ensureExistingFields();
 
     batch.flatMap((doc: DocumentBuilder) => {

--- a/src/fieldAnalyser/fieldUtils.ts
+++ b/src/fieldAnalyser/fieldUtils.ts
@@ -1,10 +1,16 @@
 import PlatformClient, {FieldModel} from '@coveord/platform-client';
+import {ensureNecessaryCoveoPrivileges} from '../validation/preconditions/apiKeyPrivilege';
+import {
+  readFieldsPrivilege,
+  writeFieldsPrivilege,
+} from '../validation/preconditions/platformPrivilege';
 
 export const listAllFieldsFromOrg = async (
   client: PlatformClient,
   page = 0,
   fields: FieldModel[] = []
 ): Promise<FieldModel[]> => {
+  await ensureNecessaryCoveoPrivileges(client, readFieldsPrivilege);
   const list = await client.field.list({
     page,
     perPage: 1000,
@@ -24,6 +30,7 @@ export const createFields = async (
   fields: FieldModel[],
   fieldBatch = 500
 ) => {
+  await ensureNecessaryCoveoPrivileges(client, writeFieldsPrivilege);
   for (let i = 0; i < fields.length; i += fieldBatch) {
     const batch = fields.slice(i, fieldBatch + i);
     await client.field.createFields(batch);

--- a/src/fieldAnalyser/fieldsUtils.spec.ts
+++ b/src/fieldAnalyser/fieldsUtils.spec.ts
@@ -6,6 +6,7 @@ import {createFields, listAllFieldsFromOrg} from './fieldUtils';
 const mockedPlatformClient = jest.mocked(PlatformClient);
 const mockedCreateField = jest.fn();
 const mockedListFields = jest.fn();
+const mockEvaluate = jest.fn();
 
 const dummyPlatformClient = (): PlatformClient => {
   return new PlatformClient({accessToken: 'xxx'});
@@ -15,6 +16,7 @@ const doMockPlatformClient = () => {
   mockedPlatformClient.mockImplementation(
     () =>
       ({
+        privilegeEvaluator: {evaluate: mockEvaluate},
         field: {
           createFields: mockedCreateField,
           list: mockedListFields,
@@ -31,6 +33,7 @@ describe('fieldUtils', () => {
 
   beforeEach(async () => {
     client = dummyPlatformClient();
+    mockEvaluate.mockResolvedValue({approved: true});
   });
 
   describe('when listing fields', () => {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -20,7 +20,10 @@ export interface UploadBatchCallbackData {
 
 export interface BatchUpdateDocumentsOptions {
   /**
-   * Whether to create fields required in the index based on the document batch metadata.
+   * Whether to create the missing fields required in the index based on the document batch metadata.
+   *
+   * Make sure your API key is granted the privilege to EDIT fields before using this option.
+   * See https://docs.coveo.com/en/1707#fields-domain
    */
   createFields?: boolean;
 }

--- a/src/source/catalog.spec.ts
+++ b/src/source/catalog.spec.ts
@@ -20,6 +20,7 @@ const mockAxios = axios as jest.Mocked<typeof axios>;
 const mockedFieldAnalyser = jest.mocked(FieldAnalyser);
 const mockedPlatformClient = jest.mocked(PlatformClient);
 const mockCreateSource = jest.fn();
+const mockEvaluate = jest.fn();
 const mockCreateField = jest.fn();
 const mockAnalyserAdd = jest.fn();
 const mockAnalyserReport = jest.fn();
@@ -56,6 +57,7 @@ const doMockPlatformClient = () => {
   mockedPlatformClient.mockImplementation(
     () =>
       ({
+        privilegeEvaluator: {evaluate: mockEvaluate},
         source: {
           create: mockCreateSource,
         },
@@ -84,6 +86,7 @@ describe('CatalogSource - Push', () => {
   });
 
   beforeEach(() => {
+    mockEvaluate.mockResolvedValue({approved: true});
     source = new CatalogSource('the_key', 'the_org');
     batch = {
       addOrUpdate: [

--- a/src/source/catalog.stream.spec.ts
+++ b/src/source/catalog.stream.spec.ts
@@ -14,6 +14,7 @@ const mockedFieldAnalyser = jest.mocked(FieldAnalyser);
 const mockedPlatformClient = jest.mocked(PlatformClient);
 const mockCreateSource = jest.fn();
 const mockCreateField = jest.fn();
+const mockEvaluate = jest.fn();
 const mockAnalyserAdd = jest.fn();
 const mockAnalyserReport = jest.fn();
 const mockedSuccessCallback = jest.fn();
@@ -46,6 +47,7 @@ const doMockPlatformClient = () => {
   mockedPlatformClient.mockImplementation(
     () =>
       ({
+        privilegeEvaluator: {evaluate: mockEvaluate},
         source: {
           create: mockCreateSource,
         },
@@ -119,6 +121,7 @@ describe('CatalogSource - Stream', () => {
   });
 
   beforeEach(() => {
+    mockEvaluate.mockResolvedValue({approved: true});
     source = new CatalogSource('the_key', 'the_org');
   });
 

--- a/src/source/push.spec.ts
+++ b/src/source/push.spec.ts
@@ -24,6 +24,7 @@ const mockAxios = axios as jest.Mocked<typeof axios>;
 const mockedFieldAnalyser = jest.mocked(FieldAnalyser);
 const mockedPlatformClient = jest.mocked(PlatformClient);
 const mockCreateSource = jest.fn();
+const mockEvaluate = jest.fn();
 const mockCreateField = jest.fn();
 const mockAnalyserAdd = jest.fn();
 const mockAnalyserReport = jest.fn();
@@ -50,6 +51,7 @@ const doMockPlatformClient = () => {
   mockedPlatformClient.mockImplementation(
     () =>
       ({
+        privilegeEvaluator: {evaluate: mockEvaluate},
         source: {
           create: mockCreateSource,
         },
@@ -78,6 +80,7 @@ describe('PushSource', () => {
 
   beforeEach(() => {
     source = new PushSource('the_key', 'the_org');
+    mockEvaluate.mockResolvedValue({approved: true});
   });
 
   const expectedDocumentsHeaders = {

--- a/src/validation/preconditions/apiKeyPrivilege.spec.ts
+++ b/src/validation/preconditions/apiKeyPrivilege.spec.ts
@@ -1,0 +1,89 @@
+jest.mock('@coveord/platform-client');
+
+import PlatformClient from '@coveord/platform-client';
+import {writeFieldsPrivilege} from './platformPrivilege';
+import {ensureNecessaryCoveoPrivileges} from './apiKeyPrivilege';
+
+const mockedPlatformClient = jest.mocked(PlatformClient);
+const mockEvaluate = jest.fn();
+
+const doMockPlatformClient = () => {
+  mockedPlatformClient.mockImplementation(
+    () =>
+      ({
+        privilegeEvaluator: {evaluate: mockEvaluate},
+      } as unknown as PlatformClient)
+  );
+};
+
+const dummyPlatformClient = (): PlatformClient => {
+  return new PlatformClient({accessToken: 'xxx'});
+};
+
+describe('ApiKeyPrivileges', () => {
+  let client: PlatformClient;
+  beforeAll(() => {
+    doMockPlatformClient();
+  });
+
+  beforeEach(async () => {
+    client = dummyPlatformClient();
+  });
+
+  describe('when not missing privileges', () => {
+    beforeEach(async () => {
+      mockEvaluate.mockResolvedValue({approved: true});
+    });
+
+    it('should call the privilege evaluator for each privilege to evaluate', async () => {
+      await ensureNecessaryCoveoPrivileges(client, writeFieldsPrivilege);
+      expect(mockEvaluate).toHaveBeenCalledTimes(3);
+    });
+
+    it.each([
+      {
+        type: 'VIEW',
+      },
+      {
+        type: 'CREATE',
+      },
+      {
+        type: 'EDIT',
+      },
+    ])('should evaluate the "$type FIELD" privilege', async ({type}) => {
+      process.stdout.write('*********************\n');
+      process.stdout.write(`${type}\n`);
+      process.stdout.write('*********************\n');
+
+      await ensureNecessaryCoveoPrivileges(client, writeFieldsPrivilege);
+      expect(mockEvaluate).toHaveBeenCalledWith({
+        requestedPrivilege: {
+          type,
+          targetDomain: 'FIELD',
+          targetId: '*',
+          owner: 'PLATFORM',
+        },
+      });
+    });
+
+    it('should not throw a Privilege Error', async () => {
+      await expect(
+        ensureNecessaryCoveoPrivileges(client, writeFieldsPrivilege)
+      ).resolves.not.toThrow();
+    });
+  });
+
+  describe('when missing privileges', () => {
+    beforeEach(async () => {
+      mockEvaluate.mockResolvedValue({approved: false});
+    });
+
+    it('should throw a Privilege Error', async () => {
+      await expect(
+        ensureNecessaryCoveoPrivileges(client, writeFieldsPrivilege)
+      ).rejects.toThrow(
+        /Your API key doesn't have the privilege to create or update fields/
+      );
+    });
+  });
+});

--- a/src/validation/preconditions/apiKeyPrivilege.ts
+++ b/src/validation/preconditions/apiKeyPrivilege.ts
@@ -6,6 +6,7 @@ import type {
 import PlatformClient from '@coveord/platform-client';
 import {PrivilegeError} from '../../errors/privilegeError';
 
+// Code copy pasted from https://github.com/coveo/cli/blob/master/packages/cli/src/lib/decorators/preconditions/apiKeyPrivilege.ts#L15
 export async function ensureNecessaryCoveoPrivileges(
   client: PlatformClient,
   ...privileges: PlatformPrivilege[]

--- a/src/validation/preconditions/apiKeyPrivilege.ts
+++ b/src/validation/preconditions/apiKeyPrivilege.ts
@@ -1,0 +1,32 @@
+import type {PlatformPrivilege} from './platformPrivilege';
+import type {
+  PrivilegeEvaluatorModel,
+  PrivilegeModel,
+} from '@coveord/platform-client';
+import PlatformClient from '@coveord/platform-client';
+import {PrivilegeError} from '../../errors/privilegeError';
+
+export async function ensureNecessaryCoveoPrivileges(
+  client: PlatformClient,
+  ...privileges: PlatformPrivilege[]
+): Promise<void | never> {
+  const promises = privileges.flatMap((privilege) =>
+    privilege.models.map(async (model) => {
+      if (!(await hasPrivilege(client, model))) {
+        const message = privilege.unsatisfiedConditionMessage;
+        throw new PrivilegeError(message);
+      }
+    })
+  );
+
+  await Promise.all(promises);
+}
+
+async function hasPrivilege(client: PlatformClient, privilege: PrivilegeModel) {
+  const model: PrivilegeEvaluatorModel = {
+    ...{requestedPrivilege: privilege},
+  };
+
+  const validation = await client.privilegeEvaluator.evaluate(model);
+  return Boolean(validation.approved);
+}

--- a/src/validation/preconditions/platformPrivilege.ts
+++ b/src/validation/preconditions/platformPrivilege.ts
@@ -1,0 +1,39 @@
+import type {PrivilegeModel} from '@coveord/platform-client';
+
+export interface PlatformPrivilege {
+  models: PrivilegeModel[];
+  unsatisfiedConditionMessage: string;
+}
+
+export const readFieldsPrivilege: PlatformPrivilege = {
+  models: [
+    {
+      type: 'VIEW',
+      targetDomain: 'FIELD',
+      targetId: '*',
+      owner: 'PLATFORM',
+    },
+  ],
+  unsatisfiedConditionMessage: `Your API key doesn't have the privilege to view fields and their configuration. Make sure to grant this privilege to your API key before running the command again.
+  See https://docs.coveo.com/en/1707#fields-domain`,
+};
+
+export const writeFieldsPrivilege: PlatformPrivilege = {
+  models: [
+    ...readFieldsPrivilege.models,
+    {
+      type: 'CREATE',
+      targetDomain: 'FIELD',
+      targetId: '*',
+      owner: 'PLATFORM',
+    },
+    {
+      type: 'EDIT',
+      targetDomain: 'FIELD',
+      targetId: '*',
+      owner: 'PLATFORM',
+    },
+  ],
+  unsatisfiedConditionMessage: `Your API key doesn't have the privilege to create or update fields. Make sure to grant this privilege to your API key before running the command again.
+  See https://docs.coveo.com/en/1707#fields-domain`,
+};


### PR DESCRIPTION
Whenever the API key does not have the required privileges, the SDK returns an error message leaving the user without information on the next steps.

This will happen if the user creates a Push or Catalog source via the Admin UI and uses the generated API key in the SDK.
Since the source creation generates an API with the minimum privileges, it will lack the privileges to list and create fields (which are required by the FieldAnalyser).

So instead of returning the API error message, we check if API key has the required privilege to perform the following API call.

### Previous Error message
![image](https://user-images.githubusercontent.com/12199712/160949682-cbe7ae89-f92f-4c04-ba65-61d721a4ad2d.png)

### New Error message
![image](https://user-images.githubusercontent.com/12199712/160949801-048a664f-2c69-4c6a-a109-5e67f203c260.png)
