### PR TITLE
fix: numeric type evolution

### DIFF
--- a/src/fieldAnalyser/fieldAnalyser.spec.ts
+++ b/src/fieldAnalyser/fieldAnalyser.spec.ts
@@ -157,6 +157,30 @@ describe('FieldAnalyser', () => {
         },
       ]);
     });
+
+    it('should always take the most englobing numeric type regardless of the transition direction', async () => {
+      const docBuilders = [
+        buildDocument({
+          from_long_to_double: 10,
+          from_double_to_long: 20.1,
+        }),
+        buildDocument({
+          from_long_to_double: 10.1,
+          from_double_to_long: 20,
+        }),
+      ];
+      const {fields} = (await analyser.add(docBuilders)).report();
+      expect(fields).toStrictEqual([
+        {
+          name: 'from_long_to_double',
+          type: 'DOUBLE',
+        },
+        {
+          name: 'from_double_to_long',
+          type: 'DOUBLE',
+        },
+      ]);
+    });
   });
 
   describe('when the batch contains inconsistent metadata', () => {

--- a/src/fieldAnalyser/typeUtils.spec.ts
+++ b/src/fieldAnalyser/typeUtils.spec.ts
@@ -1,5 +1,5 @@
 import {FieldTypes} from '@coveord/platform-client';
-import {getGuessedTypeFromValue, isValidTypeTransition} from './typeUtils';
+import {getGuessedTypeFromValue, getMostEnglobingType} from './typeUtils';
 
 describe('typeUtils', () => {
   const signedIntegerLimit = 0b1111111111111111111111111111111;
@@ -26,24 +26,58 @@ describe('typeUtils', () => {
 
   describe('when the transition is authorized', () => {
     it.each([
-      {from: FieldTypes.LONG, to: FieldTypes.LONG},
-      {from: FieldTypes.LONG, to: FieldTypes.LONG_64},
-      {from: FieldTypes.LONG, to: FieldTypes.DOUBLE},
-      {from: FieldTypes.LONG_64, to: FieldTypes.DOUBLE},
-      {from: FieldTypes.DOUBLE, to: FieldTypes.DOUBLE},
-    ])('should return true', ({from, to}) => {
-      expect(isValidTypeTransition(from, to)).toBe(true);
+      {
+        from: FieldTypes.LONG,
+        to: FieldTypes.LONG,
+        expectation: FieldTypes.LONG,
+      },
+      {
+        from: FieldTypes.LONG,
+        to: FieldTypes.LONG_64,
+        expectation: FieldTypes.LONG_64,
+      },
+      {
+        from: FieldTypes.LONG,
+        to: FieldTypes.DOUBLE,
+        expectation: FieldTypes.DOUBLE,
+      },
+      {
+        from: FieldTypes.LONG_64,
+        to: FieldTypes.DOUBLE,
+        expectation: FieldTypes.DOUBLE,
+      },
+      {
+        from: FieldTypes.DOUBLE,
+        to: FieldTypes.DOUBLE,
+        expectation: FieldTypes.DOUBLE,
+      },
+      {
+        from: FieldTypes.LONG_64,
+        to: FieldTypes.LONG,
+        expectation: FieldTypes.LONG_64,
+      },
+      {
+        from: FieldTypes.DOUBLE,
+        to: FieldTypes.LONG_64,
+        expectation: FieldTypes.DOUBLE,
+      },
+    ])('should return true', ({from, to, expectation}) => {
+      expect(getMostEnglobingType(from, to)).toBe(expectation);
     });
   });
 
   describe('when the transition is not authorized', () => {
     it.each([
-      {from: FieldTypes.LONG_64, to: FieldTypes.LONG},
-      {from: FieldTypes.DOUBLE, to: FieldTypes.LONG_64},
-      {from: FieldTypes.LONG_64, to: FieldTypes.STRING},
-      {from: FieldTypes.STRING, to: FieldTypes.LONG},
+      {
+        from: FieldTypes.LONG_64,
+        to: FieldTypes.STRING,
+      },
+      {
+        from: FieldTypes.STRING,
+        to: FieldTypes.LONG,
+      },
     ])('should return true', ({from, to}) => {
-      expect(isValidTypeTransition(from, to)).toBe(false);
+      expect(getMostEnglobingType(from, to)).toBe(null);
     });
   });
 });

--- a/src/fieldAnalyser/typeUtils.spec.ts
+++ b/src/fieldAnalyser/typeUtils.spec.ts
@@ -61,9 +61,12 @@ describe('typeUtils', () => {
         to: FieldTypes.LONG_64,
         expectation: FieldTypes.DOUBLE,
       },
-    ])('should return true', ({from, to, expectation}) => {
-      expect(getMostEnglobingType(from, to)).toBe(expectation);
-    });
+    ])(
+      'From $from to $to should return $expectation',
+      ({from, to, expectation}) => {
+        expect(getMostEnglobingType(from, to)).toBe(expectation);
+      }
+    );
   });
 
   describe('when the transition is not authorized', () => {
@@ -76,7 +79,7 @@ describe('typeUtils', () => {
         from: FieldTypes.STRING,
         to: FieldTypes.LONG,
       },
-    ])('should return true', ({from, to}) => {
+    ])('From $from to $to should return $expectation', ({from, to}) => {
       expect(getMostEnglobingType(from, to)).toBe(null);
     });
   });

--- a/src/fieldAnalyser/typeUtils.ts
+++ b/src/fieldAnalyser/typeUtils.ts
@@ -1,21 +1,28 @@
 import {FieldTypes} from '@coveord/platform-client';
 
-const acceptedTransitions: Array<{from: FieldTypes; to: Array<FieldTypes>}> = [
-  {from: FieldTypes.LONG, to: [FieldTypes.LONG_64, FieldTypes.DOUBLE]},
-  {from: FieldTypes.LONG_64, to: [FieldTypes.DOUBLE]},
+const acceptedTypeEvolutions = [
+  [FieldTypes.LONG, FieldTypes.LONG_64, FieldTypes.DOUBLE],
 ];
 
-export function isValidTypeTransition(
-  currentState: FieldTypes,
-  nextState: FieldTypes
-): boolean {
-  if (currentState === nextState) {
-    return true;
+export function getMostEnglobingType(
+  possibleType1: FieldTypes,
+  possibleType2: FieldTypes
+): FieldTypes | null {
+  if (possibleType1 === possibleType2) {
+    return possibleType1;
   }
-  const differentStateTransition = acceptedTransitions
-    .find((a) => a.from === currentState)
-    ?.to.includes(nextState);
-  return Boolean(differentStateTransition);
+
+  for (const acceptedTypeEvolution of acceptedTypeEvolutions) {
+    if (
+      acceptedTypeEvolution.includes(possibleType1) &&
+      acceptedTypeEvolution.includes(possibleType2)
+    ) {
+      const idx1 = acceptedTypeEvolution.indexOf(possibleType1);
+      const idx2 = acceptedTypeEvolution.indexOf(possibleType2);
+      return acceptedTypeEvolution[Math.max(idx1, idx2)];
+    }
+  }
+  return null;
 }
 
 export function getGuessedTypeFromValue(obj: unknown): FieldTypes {


### PR DESCRIPTION
There was an issue with the numeric type "evolution". 
When the FieldAnalyser was detecting that a field that was previously defined as Integer but now detected as float, then the more englobing type (float) was chosen.

However, the opposite scenario was causing an issue rather than sticking to the most englobing type.