### PR TITLE
feat: detect multi-value facet fields

### DIFF
--- a/src/fieldAnalyser/fieldStore.ts
+++ b/src/fieldAnalyser/fieldStore.ts
@@ -1,6 +1,6 @@
-import {FieldModel, FieldTypes} from '@coveord/platform-client';
+import {FieldModel} from '@coveord/platform-client';
 
-export class FieldStore extends Map<string, FieldTypes> {
+export class FieldStore extends Map<string, FieldModel> {
   public concat(fieldBuilder: FieldStore) {
     fieldBuilder.forEach((type, name) => {
       this.set(name, type);
@@ -9,11 +9,8 @@ export class FieldStore extends Map<string, FieldTypes> {
 
   public marshal(): FieldModel[] {
     const fieldModels: FieldModel[] = [];
-    this.forEach((fieldType, fieldName) => {
-      fieldModels.push({
-        name: fieldName,
-        type: fieldType,
-      });
+    this.forEach((model) => {
+      fieldModels.push(model);
     });
 
     return fieldModels;

--- a/src/fieldAnalyser/typeUtils.ts
+++ b/src/fieldAnalyser/typeUtils.ts
@@ -25,7 +25,22 @@ export function getMostEnglobingType(
   return null;
 }
 
+export function isMultiValueFacet(obj: unknown): boolean {
+  // Handling the most obvious use case. A multi value field could also be a string with delimiter, but we do not want to assume anything...
+  // With an array, we know for sure the metadata has multiple values
+  return Array.isArray(obj);
+}
+
+export function isHierarchicalFacet(obj: unknown): boolean {
+  // TODO: check if the array values follow a isHierarchy
+  const isHierarchical = false;
+  return isMultiValueFacet(obj) && isHierarchical;
+}
+
 export function getGuessedTypeFromValue(obj: unknown): FieldTypes {
+  if (Array.isArray(obj) && obj.length > 0) {
+    return getGuessedTypeFromValue(obj[0]); // FIXME: Not sure here. What should we use to define the type?
+  }
   switch (typeof obj) {
     case 'number':
       return getSpecificNumericType(obj);


### PR DESCRIPTION
The SDK will not detect with 100% accuracy if the field is indeed a multi-facet value.
However, for very obvious use cases (when the metadata is an array), we could consider the field as multi-value.

More info [here](https://docs.google.com/document/d/1jBiTYWcuWXgoD6R40IHwIHan8mmLohaLbu4Lt9tdbMU/edit)

This is a very rough draft just to have some code along with the google doc?

