### PR TITLE
chore: centralize default upload options

### DIFF
--- a/src/source/batchUploadDocumentsFromFile.ts
+++ b/src/source/batchUploadDocumentsFromFile.ts
@@ -21,25 +21,16 @@ export class BatchUploadDocumentsFromFilesReturn {
     platformClient: PlatformClient,
     strategy: UploadStrategy,
     filesOrDirectories: string[],
-    options?: BatchUpdateDocumentsFromFiles
+    options: Required<BatchUpdateDocumentsFromFiles>
   ) {
-    const defaultOptions = {
-      maxConcurrent: 10,
-      createFields: true,
-    };
-    const {maxConcurrent, createFields} = {
-      ...defaultOptions,
-      ...options,
-    };
-
     this.consumer = new FileConsumer(
       (batch: BatchUpdateDocuments) => strategy.upload(batch),
-      {maxConcurrent}
+      options
     );
 
     this.internalPromise = (async () => {
       const files = getAllJsonFilesFromEntries(filesOrDirectories);
-      if (createFields) {
+      if (options.createFields) {
         const analyser = new FieldAnalyser(platformClient);
         for (const filePath of files.values()) {
           const docBuilders =

--- a/src/source/catalog.ts
+++ b/src/source/catalog.ts
@@ -20,9 +20,8 @@ import {
   BatchUpdateDocumentsOptions,
 } from '../interfaces';
 import {axiosRequestHeaders} from '../help/axiosUtils';
-import {uploadBatch} from './documentUploader';
+import {uploadBatch, uploadBatchFromFile} from './documentUploader';
 import {StreamUrlBuilder} from '../help/urlUtils';
-import {BatchUploadDocumentsFromFilesReturn} from './batchUploadDocumentsFromFile';
 
 /**
  * Manage a catalog source.
@@ -81,16 +80,16 @@ export class CatalogSource {
    * See [Full Document Update](https://docs.coveo.com/en/l62e0540)
    * @param sourceId
    * @param batch
-   * @param {BatchUpdateDocumentsOptions} [{createFields: createFields = true}={}]
+   * @param {BatchUpdateDocumentsOptions}
    * @returns
    */
   public batchUpdateDocuments(
     sourceId: string,
     batch: BatchUpdateDocuments,
-    {createFields: createFields = true}: BatchUpdateDocumentsOptions = {}
+    options?: BatchUpdateDocumentsOptions
   ) {
     const strategy = this.fileContainerStrategy(sourceId);
-    return uploadBatch(this.platformClient, strategy, batch, createFields);
+    return uploadBatch(this.platformClient, strategy, batch, options);
   }
 
   /**
@@ -98,15 +97,15 @@ export class CatalogSource {
    * See [How to Stream Your Catalog Data to Your Source](https://docs.coveo.com/en/lb4a0344)
    * @param {string} sourceId
    * @param {BatchUpdateDocuments} batch
-   * @param {BatchUpdateDocumentsOptions} [{createFields: createFields = true}={}]
+   * @param {BatchUpdateDocumentsOptions}
    */
   public async batchStreamDocuments(
     sourceId: string,
     batch: BatchUpdateDocuments,
-    {createFields: createFields = true}: BatchUpdateDocumentsOptions = {}
+    options?: BatchUpdateDocumentsOptions
   ) {
     const strategy = this.streamChunkStrategy(sourceId);
-    await uploadBatch(this.platformClient, strategy, batch, createFields);
+    await uploadBatch(this.platformClient, strategy, batch, options);
   }
 
   /**
@@ -120,7 +119,7 @@ export class CatalogSource {
     filesOrDirectories: string[],
     options?: BatchUpdateDocumentsFromFiles
   ) {
-    return new BatchUploadDocumentsFromFilesReturn(
+    return uploadBatchFromFile(
       this.platformClient,
       this.fileContainerStrategy(sourceId),
       filesOrDirectories,
@@ -140,7 +139,7 @@ export class CatalogSource {
     filesOrDirectories: string[],
     options?: BatchUpdateDocumentsFromFiles
   ) {
-    return new BatchUploadDocumentsFromFilesReturn(
+    return uploadBatchFromFile(
       this.platformClient,
       this.streamChunkStrategy(sourceId),
       filesOrDirectories,

--- a/src/source/documentUploader.ts
+++ b/src/source/documentUploader.ts
@@ -1,17 +1,67 @@
 import PlatformClient from '@coveord/platform-client';
-import {AxiosResponse} from 'axios';
+import axios, {AxiosRequestConfig, AxiosResponse} from 'axios';
 import {FieldAnalyser} from '..';
+import {DocumentBuilder} from '../documentBuilder';
 import {FieldTypeInconsistencyError} from '../errors/fieldErrors';
 import {createFields as create} from '../fieldAnalyser/fieldUtils';
-import {BatchUpdateDocuments} from '../interfaces';
+import {
+  BatchUpdateDocuments,
+  BatchUpdateDocumentsFromFiles,
+  BatchUpdateDocumentsOptions,
+} from '../interfaces';
 import {UploadStrategy} from '../uploadStrategy';
+import {BatchUploadDocumentsFromFilesReturn} from './batchUploadDocumentsFromFile';
+
+const defaultBatchOptions: Required<BatchUpdateDocumentsOptions> = {
+  createFields: true,
+};
+
+const defaultBatchFromFileOptions: Required<BatchUpdateDocumentsFromFiles> = {
+  ...defaultBatchOptions,
+  maxConcurrent: 10,
+};
+
+export async function uploadDocument(
+  platformClient: PlatformClient,
+  docBuilder: DocumentBuilder,
+  addURL: URL,
+  documentsAxiosConfig: AxiosRequestConfig,
+  options?: BatchUpdateDocumentsFromFiles
+) {
+  const {createFields}: Required<BatchUpdateDocumentsFromFiles> = {
+    ...defaultBatchFromFileOptions,
+    ...options,
+  };
+  if (createFields) {
+    const analyser = new FieldAnalyser(platformClient);
+    await analyser.add([docBuilder]);
+    const {fields, inconsistencies} = analyser.report();
+    if (inconsistencies.size > 0) {
+      throw new FieldTypeInconsistencyError(inconsistencies);
+    }
+
+    await create(platformClient, fields);
+  }
+
+  const doc = docBuilder.build();
+  addURL.searchParams.append('documentId', doc.uri);
+  return axios.put(
+    addURL.toString(),
+    docBuilder.marshal(),
+    documentsAxiosConfig
+  );
+}
 
 export async function uploadBatch(
   platformClient: PlatformClient,
   strategy: UploadStrategy,
   batch: BatchUpdateDocuments,
-  createFields = true
+  options?: BatchUpdateDocumentsOptions
 ): Promise<AxiosResponse> {
+  const {createFields}: BatchUpdateDocumentsOptions = {
+    ...defaultBatchOptions,
+    ...options,
+  };
   if (createFields) {
     const analyser = new FieldAnalyser(platformClient);
     await analyser.add(batch.addOrUpdate);
@@ -27,4 +77,22 @@ export async function uploadBatch(
   await strategy.postUpload?.();
 
   return res;
+}
+
+export function uploadBatchFromFile(
+  platformClient: PlatformClient,
+  strategy: UploadStrategy,
+  filesOrDirectories: string[],
+  options?: BatchUpdateDocumentsFromFiles
+) {
+  const opts: Required<BatchUpdateDocumentsFromFiles> = {
+    ...defaultBatchFromFileOptions,
+    ...options,
+  };
+  return new BatchUploadDocumentsFromFilesReturn(
+    platformClient,
+    strategy,
+    filesOrDirectories,
+    opts
+  );
 }

--- a/src/validation/preconditions/apiKeyPrivilege.spec.ts
+++ b/src/validation/preconditions/apiKeyPrivilege.spec.ts
@@ -51,10 +51,6 @@ describe('ApiKeyPrivileges', () => {
         type: 'EDIT',
       },
     ])('should evaluate the "$type FIELD" privilege', async ({type}) => {
-      process.stdout.write('*********************\n');
-      process.stdout.write(`${type}\n`);
-      process.stdout.write('*********************\n');
-
       await ensureNecessaryCoveoPrivileges(client, writeFieldsPrivilege);
       expect(mockEvaluate).toHaveBeenCalledWith({
         requestedPrivilege: {


### PR DESCRIPTION
No change in functionality.
Simply move the upload methods into the same file (`documentUploader.ts`) to have a single place where default upload options are defined.