### PR TITLE
ci: fix tests in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
         run: npm ci
       - name: Check linting
         run: npm run lint
-      - name: Build
-        run: npm run build
       - name: Tests
         run: npm run test
+      - name: Build
+        run: npm run build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
         run: npm ci
       - name: Check linting
         run: npm run lint
-      - name: Tests
-        run: npm run test
       - name: Build
         run: npm run build
+      - name: Tests
+        run: npm run test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,10 +22,10 @@ jobs:
         run: |
           git config --global user.email action@github.com
           git config --global user.name GitHub Action
-      - name: Build
-        run: npm run build
       - name: Test
         run: npm run test
+      - name: Build
+        run: npm run build
       - name: Release
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Issue
Unit tests fail when running in CD. [Last run](https://github.com/coveo/push-api-client.js/actions/runs/2352254637).

The test passes while running ./src files
 ![image](https://user-images.githubusercontent.com/12199712/169384797-23da08b4-a68a-42eb-902e-decbd5f20c65.png)

The test fails while running ./dist files
![image](https://user-images.githubusercontent.com/12199712/169384826-7a8cde05-433d-4ec5-b290-f5d83852acb3.png)

All tests are running twice. One time from the src folder and another time from the dist folder.
Seems like the snapshot are not found for the tests in the dist folder.

## Solution
Run the tests before doing a build to prevent running the same tests twice.