### PR TITLE
chore(jest): ignore `dist` for ut

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -6,4 +6,5 @@ module.exports = {
   clearMocks: true,
   silent: true,
   testTimeout: 60e3,
+  testPathIgnorePatterns: ['/node_modules/', '/dist/'],
 };


### PR DESCRIPTION
We run the UT on src, not dist.