### PR TITLE
fix: inscrease axios body size

### DIFF
--- a/src/help/__snapshots__/fileContainer.spec.ts.snap
+++ b/src/help/__snapshots__/fileContainer.spec.ts.snap
@@ -2,6 +2,6 @@
 
 exports[`#uploadContentToFileContainer when an MaxBodyLengthExceededError is thrown should give some info on how to fix it 1`] = `
 "some initial message
-File size is limited to 5 MB.
+File container size limit exceeded.
 See <https://docs.coveo.com/en/63/index-content/push-api-limits#request-size-limits>."
 `;

--- a/src/help/fileConsumer.ts
+++ b/src/help/fileConsumer.ts
@@ -20,7 +20,7 @@ export type FailedUploadCallback = (
  * Util class to help injesting documents through a list of files and uploading generated document batches.
  */
 export class FileConsumer {
-  public static maxContentLength = 5 * 1024 * 1024;
+  private static maxContentLength = 5 * 1024 * 1024;
   private cbSuccess: SuccessfulUploadCallback = () => {};
   private cbFail: FailedUploadCallback = () => {};
 

--- a/src/help/fileConsumer.ts
+++ b/src/help/fileConsumer.ts
@@ -20,7 +20,7 @@ export type FailedUploadCallback = (
  * Util class to help injesting documents through a list of files and uploading generated document batches.
  */
 export class FileConsumer {
-  private static maxContentLength = 5 * 1024 * 1024;
+  public static maxContentLength = 5 * 1024 * 1024;
   private cbSuccess: SuccessfulUploadCallback = () => {};
   private cbFail: FailedUploadCallback = () => {};
 

--- a/src/help/fileContainer.spec.ts
+++ b/src/help/fileContainer.spec.ts
@@ -45,7 +45,7 @@ describe('#uploadContentToFileContainer', () => {
         headers: {
           foo: 'bar',
         },
-        maxBodyLength: 5e3,
+        maxBodyLength: 256e6,
       }
     );
   });

--- a/src/help/fileContainer.ts
+++ b/src/help/fileContainer.ts
@@ -1,6 +1,7 @@
 import axios, {AxiosRequestConfig} from 'axios';
 import {URL} from 'url';
 import {BatchUpdateDocuments} from '../interfaces';
+import {FileConsumer} from './fileConsumer';
 
 export interface FileContainerResponse {
   uploadUri: string;
@@ -36,9 +37,10 @@ export const uploadContentToFileContainer = async (
 export const getFileContainerAxiosConfig = (
   fileContainer: FileContainerResponse
 ): AxiosRequestConfig => {
+  const buffer = 1e6; // One megabyte buffer
   return {
     headers: fileContainer.requiredHeaders,
-    maxBodyLength: 5e3,
+    maxBodyLength: FileConsumer.maxContentLength + buffer,
   };
 };
 

--- a/src/help/fileContainer.ts
+++ b/src/help/fileContainer.ts
@@ -1,7 +1,6 @@
 import axios, {AxiosRequestConfig} from 'axios';
 import {URL} from 'url';
 import {BatchUpdateDocuments} from '../interfaces';
-import {FileConsumer} from './fileConsumer';
 
 export interface FileContainerResponse {
   uploadUri: string;
@@ -28,7 +27,7 @@ export const uploadContentToFileContainer = async (
     .catch((err) => {
       if (isMaxBodyLengthExceededError(err)) {
         err.message +=
-          '\nFile size is limited to 5 MB.\nSee <https://docs.coveo.com/en/63/index-content/push-api-limits#request-size-limits>.';
+          '\nFile container size limit exceeded.\nSee <https://docs.coveo.com/en/63/index-content/push-api-limits#request-size-limits>.';
       }
       throw err;
     });
@@ -37,10 +36,9 @@ export const uploadContentToFileContainer = async (
 export const getFileContainerAxiosConfig = (
   fileContainer: FileContainerResponse
 ): AxiosRequestConfig => {
-  const buffer = 1e6; // One megabyte buffer
   return {
     headers: fileContainer.requiredHeaders,
-    maxBodyLength: FileConsumer.maxContentLength + buffer,
+    maxBodyLength: 256e6,
   };
 };
 

--- a/src/source/catalog.spec.ts
+++ b/src/source/catalog.spec.ts
@@ -144,7 +144,7 @@ describe('CatalogSource - Push', () => {
             expect.objectContaining({documentId: 'the_uri_3'}),
           ]),
         }),
-        {headers: {foo: 'bar'}, maxBodyLength: 5e3}
+        {headers: {foo: 'bar'}, maxBodyLength: 256e6}
       );
     });
 
@@ -195,7 +195,7 @@ describe('CatalogSource - Push', () => {
           headers: {
             foo: 'bar',
           },
-          maxBodyLength: 5e3,
+          maxBodyLength: 256e6,
         }
       );
     });

--- a/src/source/catalog.stream.spec.ts
+++ b/src/source/catalog.stream.spec.ts
@@ -166,7 +166,7 @@ describe('CatalogSource - Stream', () => {
           headers: {
             foo: 'bar',
           },
-          maxBodyLength: 5e3,
+          maxBodyLength: 256e6,
         }
       );
     });
@@ -212,7 +212,7 @@ describe('CatalogSource - Stream', () => {
             headers: {
               foo: 'bar',
             },
-            maxBodyLength: 5e3,
+            maxBodyLength: 256e6,
           }
         );
       });

--- a/src/source/push.spec.ts
+++ b/src/source/push.spec.ts
@@ -262,7 +262,7 @@ describe('PushSource', () => {
             expect.objectContaining({documentId: 'the_uri_3'}),
           ]),
         }),
-        {headers: {foo: 'bar'}, maxBodyLength: 5e3}
+        {headers: {foo: 'bar'}, maxBodyLength: 256e6}
       );
     });
 
@@ -313,7 +313,7 @@ describe('PushSource', () => {
           headers: {
             foo: 'bar',
           },
-          maxBodyLength: 5e3,
+          maxBodyLength: 256e6,
         }
       );
     });


### PR DESCRIPTION
I removed the maximum body limit of 5KB. It was set to 5KB instead of 5MB. This was causing requests larger than 5KB to return an error.

The request size limits of the Push API could change at any time without prior notice, so it does not make sense for the SDK to impose a lower limit that could be deprecated in the future. That's why I would simply set the `maxBodyLength` value to the limit of a file container (256MB). As long as the limit is bigger than the document chunk size.


