### PR TITLE
fix: open stream only once

### DIFF
--- a/src/__stub__/largeDocuments/documentGenerator.ts
+++ b/src/__stub__/largeDocuments/documentGenerator.ts
@@ -1,0 +1,20 @@
+const batmanCloner = (id: number) => ({
+  DocumentId: `https://www.themoviedb.org/movie/${id}`,
+  data: 'Batman (1989) \n Based on the Character created by Bob Kane. \n EXT. CITYSCAPE - NIGHT \n Gotham City.  The City of Tomorrow:  stark angles, creeping shadows, dense, crowded, as if hell had erupted through the sidewalks.  A dangling fat moon shines overhead. \n At the opposite corner of the roof, some fifteen yards away... at the end of a line, a STRANGE BLACK SILHOUETTE is dropping slowly, implacably, into frame...',
+  fileExtension: '.txt',
+  title: 'Batman',
+  year: 1989,
+  date: '1989-06-13T12:00:00.000Z',
+  summary:
+    "The Dark Knight of Gotham City begins his war on crime with his first major enemy being the clownishly homicidal Joker, who has seized control of Gotham's underworld.",
+  tagline: 'Have you ever danced with the devil in the pale moonlight?',
+  actors: ['Jack Nicholson', 'Michael Keaton', 'Kim Basinger'],
+  poster:
+    '//image.tmdb.org/t/p/w185_and_h278_bestv2/kBf3g9crrADGMc2AMAMlLBgSm2h.jpg',
+});
+
+export const generateBatmans = (batmanCount: number) => {
+  return Array(batmanCount)
+    .fill(null)
+    .map((_, idx) => batmanCloner(idx));
+};

--- a/src/source/batchUploadDocumentsFromFile.ts
+++ b/src/source/batchUploadDocumentsFromFile.ts
@@ -29,6 +29,8 @@ export class BatchUploadDocumentsFromFilesReturn {
 
     this.internalPromise = (async () => {
       const files = getAllJsonFilesFromEntries(filesOrDirectories);
+      await strategy.preUpload?.();
+
       if (options.createFields) {
         const analyser = new FieldAnalyser(platformClient);
         for (const filePath of files.values()) {

--- a/src/uploadStrategy/strategy.ts
+++ b/src/uploadStrategy/strategy.ts
@@ -10,6 +10,14 @@ export interface UploadStrategy {
   upload: (batch: BatchUpdateDocuments) => Promise<AxiosResponse>;
 
   /**
+   * Async operation to run before starting the upload
+   * This can be useful if a task should to run before the parallel uploads
+   *
+   * @memberof UploadStrategy
+   */
+  preUpload?: () => Promise<void>;
+
+  /**
    * Async operation to run once the batch upload is complete
    *
    * @memberof UploadStrategy


### PR DESCRIPTION
## Issue
A new stream was opened for every chunk to upload.
Each chunk was sent to a different stream and only the last opened stream was uploaded to the S3 file container...
This is the result of pushing multiple chunks in parallel.
**Consequence**: All the previous stream chunks die alone because they never reach the Coveo index.

## Fix
Create a `preUpload` hook to open a single stream before starting the upload phase.