### PR TITLE
fix(stream): add missing preUpload

### DIFF
--- a/src/source/catalog.stream.spec.ts
+++ b/src/source/catalog.stream.spec.ts
@@ -7,7 +7,7 @@ import axios from 'axios';
 import {join} from 'path';
 import {cwd} from 'process';
 import {CatalogSource} from './catalog';
-import {FieldAnalyser} from '..';
+import {DocumentBuilder, FieldAnalyser} from '..';
 import {generateBatmans} from '../__stub__/largeDocuments/documentGenerator';
 import {rmSync, writeFileSync, mkdirSync} from 'fs';
 const mockAxios = axios as jest.Mocked<typeof axios>;
@@ -140,6 +140,26 @@ describe('CatalogSource - Stream', () => {
   });
 
   describe('when streaming data from a batch', () => {
+    beforeEach(async () => {
+      mockSuccessAxiosCalls();
+      await source.batchStreamDocuments(
+        'the_id',
+        {
+          addOrUpdate: [new DocumentBuilder('uri', 'title')],
+          delete: [],
+        },
+        {createFields: false}
+      );
+    });
+
+    afterAll(() => {
+      mockAxios.post.mockReset();
+    });
+
+    basicStreamExpectations();
+  });
+
+  describe('when streaming data from a file', () => {
     beforeEach(async () => {
       mockSuccessAxiosCalls();
       await source

--- a/src/source/documentUploader.ts
+++ b/src/source/documentUploader.ts
@@ -66,6 +66,7 @@ export async function uploadBatch(
     const report = analyser.report();
     await createFieldsFromReport(platformClient, report);
   }
+  await strategy.preUpload?.();
   const res = await strategy.upload(batch);
   await strategy.postUpload?.();
 


### PR DESCRIPTION
The `catalogSource#batchStreamDocuments`   was not running the preUpload.
Consequence: No stream was opened before indexation