### PR TITLE
feat(fieldanalyser): support dictionary fields

### DIFF
--- a/samples/pushDocumentWithMetadata.ts
+++ b/samples/pushDocumentWithMetadata.ts
@@ -17,6 +17,11 @@ async function main() {
       tags: ['the_first_tag', 'the_second_tag'],
       version: 1,
       somekey: 'some value',
+      dictionaryfield: {
+        '': 'default',
+        key1: 'value1',
+        key2: 'value2',
+      },
     });
 
   await source.addOrUpdateDocument('my_source_id', myDocument);

--- a/src/document.ts
+++ b/src/document.ts
@@ -33,7 +33,9 @@ export interface SecurityIdentity {
   securityProvider?: string;
 }
 
-export type MetadataValue = string | string[] | number | number[] | boolean;
+type BaseMetadataValue = string | string[] | number | number[] | boolean;
+type DictionaryMetadataValue = Record<string, BaseMetadataValue>;
+export type MetadataValue = BaseMetadataValue | DictionaryMetadataValue;
 export type Metadata = Record<string, MetadataValue>;
 
 /**

--- a/src/documentBuilder.spec.ts
+++ b/src/documentBuilder.spec.ts
@@ -46,8 +46,18 @@ describe('DocumentBuilder', () => {
 
   it('should marshal metadata', () => {
     expect(
-      docBuilder.withMetadata({foo: 'bar', buzz: ['bazz', 'bozz']}).marshal()
-    ).toMatchObject({foo: 'bar', buzz: ['bazz', 'bozz']});
+      docBuilder
+        .withMetadata({
+          foo: 'bar',
+          buzz: ['bazz', 'bozz'],
+          baz: {'': 'defaultValue', key1: 'value1'},
+        })
+        .marshal()
+    ).toMatchObject({
+      foo: 'bar',
+      buzz: ['bazz', 'bozz'],
+      baz: {'': 'defaultValue', key1: 'value1'},
+    });
   });
 
   it('should throw error for invalid single metadata value', () => {

--- a/src/fieldAnalyser/typeUtils.spec.ts
+++ b/src/fieldAnalyser/typeUtils.spec.ts
@@ -83,4 +83,16 @@ describe('typeUtils', () => {
       expect(getMostEnglobingType(from, to)).toBe(null);
     });
   });
+
+  describe('when the value is not a primitive', () => {
+    describe('when elements are not consistent', () => {
+      it.todo('should fallback on string type');
+    });
+
+    describe('when elements are consistent', () => {
+      // TODO: with array
+      // TODO: with object
+      it.todo('should pick up the right type');
+    });
+  });
 });

--- a/src/fieldAnalyser/typeUtils.spec.ts
+++ b/src/fieldAnalyser/typeUtils.spec.ts
@@ -85,14 +85,72 @@ describe('typeUtils', () => {
   });
 
   describe('when the value is not a primitive', () => {
-    describe('when elements are not consistent', () => {
-      it.todo('should fallback on string type');
+    describe('when the object contains inconsistencies', () => {
+      it.each([
+        {
+          object: {
+            key1: 42,
+            key2: '123',
+            key3: 12.23,
+          },
+          mostEnglobingType: FieldTypes.STRING,
+        },
+        {
+          object: [42, '123', 12.23],
+          mostEnglobingType: FieldTypes.STRING,
+        },
+        {
+          object: {
+            key1: 12,
+            key2: 42.32,
+          },
+          mostEnglobingType: FieldTypes.DOUBLE,
+        },
+        {
+          object: [12, 42.32],
+          mostEnglobingType: FieldTypes.DOUBLE,
+        },
+      ])(
+        'should fallback on the most englobing type',
+        ({object, mostEnglobingType}) => {
+          expect(getGuessedTypeFromValue(object)).toEqual(mostEnglobingType);
+        }
+      );
     });
 
-    describe('when elements are consistent', () => {
-      // TODO: with array
-      // TODO: with object
-      it.todo('should pick up the right type');
+    describe('when the object does not contain inconsistencies', () => {
+      it.each([
+        {
+          object: {
+            key1: 12,
+            key2: 0,
+          },
+          objectType: FieldTypes.LONG,
+        },
+        {
+          object: [12, 0],
+          objectType: FieldTypes.LONG,
+        },
+      ])(
+        'should fallback on the type of all the object values/elements',
+        ({object, objectType}) => {
+          expect(getGuessedTypeFromValue(object)).toEqual(objectType);
+        }
+      );
+    });
+
+    describe('when the value is a multi-level object', () => {
+      it('should return a string type', () => {
+        const multiLevelObject = {
+          level: {
+            anotherLevel: {
+              anotherLevelDeep: 123,
+            },
+          },
+        };
+        const guessedType = getGuessedTypeFromValue(multiLevelObject);
+        expect(guessedType).toEqual(FieldTypes.STRING);
+      });
     });
   });
 });

--- a/src/fieldAnalyser/typeUtils.ts
+++ b/src/fieldAnalyser/typeUtils.ts
@@ -1,7 +1,9 @@
 import {FieldTypes} from '@coveord/platform-client';
 
 const acceptedNumericalTypeEvolutions = [
-  [FieldTypes.LONG, FieldTypes.LONG_64, FieldTypes.DOUBLE],
+  FieldTypes.LONG,
+  FieldTypes.LONG_64,
+  FieldTypes.DOUBLE,
 ];
 
 const acceptedAllTypeEvolutions = [
@@ -11,21 +13,20 @@ const acceptedAllTypeEvolutions = [
 
 export function getMostEnglobingType(
   possibleType1: FieldTypes,
-  possibleType2: FieldTypes
+  possibleType2: FieldTypes,
+  acceptedTypeEvolution = acceptedNumericalTypeEvolutions
 ): FieldTypes | null {
   if (possibleType1 === possibleType2) {
     return possibleType1;
   }
 
-  for (const acceptedTypeEvolution of acceptedNumericalTypeEvolutions) {
-    if (
-      acceptedTypeEvolution.includes(possibleType1) &&
-      acceptedTypeEvolution.includes(possibleType2)
-    ) {
-      const idx1 = acceptedTypeEvolution.indexOf(possibleType1);
-      const idx2 = acceptedTypeEvolution.indexOf(possibleType2);
-      return acceptedTypeEvolution[Math.max(idx1, idx2)];
-    }
+  if (
+    acceptedTypeEvolution.includes(possibleType1) &&
+    acceptedTypeEvolution.includes(possibleType2)
+  ) {
+    const idx1 = acceptedTypeEvolution.indexOf(possibleType1);
+    const idx2 = acceptedTypeEvolution.indexOf(possibleType2);
+    return acceptedTypeEvolution[Math.max(idx1, idx2)];
   }
   return null;
 }
@@ -58,10 +59,11 @@ function getGuessedTypeFromObject(obj: null | Object): FieldTypes {
   const array = Array.isArray(obj) ? obj : Object.values(obj);
   return (
     array.reduce(
-      (previous: unknown, current: unknown) =>
+      (previous: FieldTypes, current: unknown) =>
         getMostEnglobingType(
-          getGuessedTypeFromPrimitive(previous),
-          getGuessedTypeFromPrimitive(current)
+          previous,
+          getGuessedTypeFromPrimitive(current),
+          acceptedAllTypeEvolutions
         ),
       initialType
     ) || fallbackType


### PR DESCRIPTION
Support [dictionary fields](https://docs.coveo.com/en/2036/index-content/about-fields#index-dictionary-fields), which can be used in commerce implementations. 

* Update `MetadataValue` type to support objects
* Detect most englobing type of a dictionary field. If the dictionary is inconsistent, the String type will be used as the most englobing one.