### PR TITLE
fix: memory leak on async callback

### DIFF
--- a/src/help/fileConsumer.ts
+++ b/src/help/fileConsumer.ts
@@ -45,9 +45,9 @@ export class FileConsumer {
     };
 
     // parallelize uploads across multiple files
-    const fileGenerator = function* () {
+    const fileGenerator = async function* () {
       for (const filePath of files.values()) {
-        const docBuilders = parseAndGetDocumentBuilderFromJSONDocument(
+        const docBuilders = await parseAndGetDocumentBuilderFromJSONDocument(
           filePath,
           options
         );

--- a/src/help/generator.spec.ts
+++ b/src/help/generator.spec.ts
@@ -31,17 +31,29 @@ describe('generator', () => {
     }
   };
 
-  it('test', async () => {
-    const callback = jest.fn();
+  const asyncGenerator = async function* () {
+    yield* generator();
+  };
+
+  const callback = jest.fn();
+  const callSequence: [worker: number, promiseId: number][] = [
+    [0, 5],
+    [0, 1],
+    [0, 3],
+    [1, 6],
+    [1, 2],
+    [1, 4],
+  ];
+
+  it('should consume a generator', async () => {
     await consumeGenerator(generator, maxConcurrent, callback);
-    const callSequence: [worker: number, promiseId: number][] = [
-      [0, 5],
-      [0, 1],
-      [0, 3],
-      [1, 6],
-      [1, 2],
-      [1, 4],
-    ];
+    callSequence.forEach((step) => {
+      expect(callback).toHaveBeenCalledWith(step[0], step[1]);
+    });
+  });
+
+  it('should consume an async generator', async () => {
+    await consumeGenerator(asyncGenerator, maxConcurrent, callback);
     callSequence.forEach((step) => {
       expect(callback).toHaveBeenCalledWith(step[0], step[1]);
     });

--- a/src/help/generator.ts
+++ b/src/help/generator.ts
@@ -1,4 +1,6 @@
-type PromiseGenerator<T> = Generator<Promise<T>, void, unknown>;
+type PromiseGenerator<T> =
+  | Generator<Promise<T>, void, unknown>
+  | AsyncGenerator<T, void, unknown>;
 
 const createWorkers = <T>(
   generator: () => PromiseGenerator<T>,
@@ -16,7 +18,7 @@ const createWorkers = <T>(
 };
 
 /**
- * Consumes a generator function concurrently
+ * Consumes a generator or an async generator function concurrently
  *
  * @template T
  * @param {() => PromiseGenerator<T>} generator The generator function to consume.
@@ -32,7 +34,7 @@ export const consumeGenerator = async <T>(
     generator: PromiseGenerator<T>,
     workerIndex: number
   ): Promise<T | void> => {
-    const next = generator.next();
+    const next = await generator.next();
     if (next.done) {
       return;
     }

--- a/src/source/batchUploadDocumentsFromFile.ts
+++ b/src/source/batchUploadDocumentsFromFile.ts
@@ -34,7 +34,7 @@ export class BatchUploadDocumentsFromFilesReturn {
       if (options.createFields) {
         const analyser = new FieldAnalyser(platformClient);
         for (const filePath of files.values()) {
-          const docBuilders = parseAndGetDocumentBuilderFromJSONDocument(
+          const docBuilders = await parseAndGetDocumentBuilderFromJSONDocument(
             filePath,
             options
           );

--- a/src/validation/parseFile.spec.ts
+++ b/src/validation/parseFile.spec.ts
@@ -8,11 +8,11 @@ describe('parseFile', () => {
   const parse = (file: string) => () =>
     parseAndGetDocumentBuilderFromJSONDocument(file);
 
-  it('should accept non-url documentIDs', () => {
+  it('should accept non-url documentIDs', async () => {
     const file = join(pathToStub, 'jsondocuments', 'notAnUrl.json');
-    expect(() =>
+    await expect(
       parseAndGetDocumentBuilderFromJSONDocument(file)
-    ).not.toThrow();
+    ).resolves.not.toThrow();
   });
 
   it.each([
@@ -47,9 +47,9 @@ describe('parseFile', () => {
       error:
         'allowedpermissions:   value should be one of: UNKNOWN, USER, GROUP, VIRTUAL_GROUP.',
     },
-  ])('$title', ({fileName, error}) => {
+  ])('$title', async ({fileName, error}) => {
     const file = join(pathToStub, 'jsondocuments', fileName);
-    expect(parse(file)).toThrow(
+    await expect(parse(file)).rejects.toThrow(
       new InvalidDocument(
         file,
         `Document contains an invalid value for ${error}`
@@ -57,9 +57,9 @@ describe('parseFile', () => {
     );
   });
 
-  it('should fail on reserved keyword', () => {
+  it('should fail on reserved keyword', async () => {
     const file = join(pathToStub, 'jsondocuments', 'reservedKeyword.json');
-    expect(parse(file)).toThrow(
+    await expect(parse(file)).rejects.toThrow(
       new InvalidDocument(
         file,
         'Cannot use parentid as a metadata key: It is a reserved key name. See https://docs.coveo.com/en/78/index-content/push-api-reference#json-document-reserved-key-names'
@@ -67,8 +67,8 @@ describe('parseFile', () => {
     );
   });
 
-  it('should fail on unsupported metadata key', () => {
+  it('should fail on unsupported metadata key', async () => {
     const file = join(pathToStub, 'jsondocuments', 'invalidFields.json');
-    expect(parse(file)).toThrowErrorMatchingSnapshot();
+    await expect(parse(file)).rejects.toThrowErrorMatchingSnapshot();
   });
 });


### PR DESCRIPTION
The `parseAndGetDocumentBuilderFromJSONDocument` could accept an async callback that was executed every time the generator was iterating over a new document.
However, the generator was not waiting for the callback resolution to iterate over the next value... therefore loading in memory all the unresolved promises.