### PR TITLE
chore(deps): update axios to alpha version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@coveo/bueno": "^0.42.0",
         "@coveo/platform-client": "37.7.0",
         "abortcontroller-polyfill": "^1.7.1",
-        "axios": "^1.0.0",
+        "axios": "^1.2.0-alpha.1",
         "dayjs": "^1.10.4",
         "exponential-backoff": "^3.1.0",
         "isomorphic-fetch": "^3.0.0"
@@ -837,22 +837,8 @@
       }
     },
     "node_modules/@coveo/push-api-client": {
-      "version": "2.7.4",
-      "resolved": "file:",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@coveo/bueno": "^0.42.0",
-        "@coveo/platform-client": "37.7.0",
-        "abortcontroller-polyfill": "^1.7.1",
-        "axios": "^1.0.0",
-        "dayjs": "^1.10.4",
-        "exponential-backoff": "^3.1.0",
-        "isomorphic-fetch": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=14.16.1"
-      }
+      "resolved": "",
+      "link": true
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
@@ -2481,9 +2467,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.1.3.tgz",
-      "integrity": "sha512-00tXVRwKx/FZr/IDVFt4C+f9FYairX517WoGCL6dpOntqLkZofjhu43F/Xl44UOpqa+9sLFDrG/XAnFsUYgkDA==",
+      "version": "1.2.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.2.0-alpha.1.tgz",
+      "integrity": "sha512-qt/7xkSQNBRKP26mt28cmSI1Y3jVtrQzu7oLjIyUHEdjpVeg100luMJrRpBlKlCmMd233Peu00mOkNC1OwXOrw==",
       "dependencies": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   ],
   "type": "commonjs",
   "types": "./dist/definitions/index.d.ts",
+  "//": "TODO: CDX-1239: Drop axios alpha version",
   "dependencies": {
     "@coveo/bueno": "^0.42.0",
     "@coveo/platform-client": "37.7.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@coveo/bueno": "^0.42.0",
     "@coveo/platform-client": "37.7.0",
     "abortcontroller-polyfill": "^1.7.1",
-    "axios": "^1.0.0",
+    "axios": "^1.2.0-alpha.1",
     "dayjs": "^1.10.4",
     "exponential-backoff": "^3.1.0",
     "isomorphic-fetch": "^3.0.0"


### PR DESCRIPTION
Cannot consume axios typescript types using CommonJS since Axios released v1.
This impacts the CLI and any clients consuming the push-api-client within a Typescript project.

Until Axios releases a official version, we will be using the alpha in which the issue has been fixed.