### PR TITLE
chore(cd): ensure we update package-lock.json on release

### DIFF
--- a/fixLock.mjs
+++ b/fixLock.mjs
@@ -1,0 +1,12 @@
+// TODO: @louis-bompart 2023, Open a bug to NPM. lockfile doesn't update version of self-import. boo. If you read this past Jan 10th and you're not @louis-bompart, poke him.
+
+import {readFileSync, writeFileSync} from 'node:fs';
+import detectIndent from 'detect-indent';
+
+let lock = readFileSync('package-lock.json', 'utf8');
+const indent = detectIndent(lock).indent;
+console.log(indent)
+const lockJSON = JSON.parse(lock);
+lockJSON.packages['node_modules/@coveo/push-api-client'].version =
+  lockJSON.version;
+writeFileSync('package-lock.json',JSON.stringify(lockJSON, undefined, indent));

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@coveo/push-api-client",
-  "version": "2.7.12",
+  "version": "2.7.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@coveo/push-api-client",
-      "version": "2.7.12",
+      "version": "2.7.13",
       "license": "Apache-2.0",
       "dependencies": {
         "@coveo/bueno": "^0.42.0",
@@ -24,6 +24,7 @@
         "@typescript-eslint/eslint-plugin": "5.45.1",
         "@typescript-eslint/parser": "5.45.1",
         "cz-conventional-changelog": "3.3.0",
+        "detect-indent": "7.0.1",
         "dotenv": "16.0.3",
         "eslint": "8.29.0",
         "eslint-config-prettier": "8.5.0",
@@ -839,7 +840,7 @@
       }
     },
     "node_modules/@coveo/push-api-client": {
-      "version": "2.7.11",
+      "version": "2.7.13",
       "resolved": "file:",
       "dev": true,
       "license": "Apache-2.0",
@@ -3161,6 +3162,15 @@
         "node": ">= 12"
       }
     },
+    "node_modules/commitizen/node_modules/detect-indent": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.1.0.tgz",
+      "integrity": "sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/compare-func": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-2.0.0.tgz",
@@ -3931,12 +3941,12 @@
       }
     },
     "node_modules/detect-indent": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.1.0.tgz",
-      "integrity": "sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-7.0.1.tgz",
+      "integrity": "sha512-Mc7QhQ8s+cLrnUfU/Ji94vG/r8M26m8f++vyres4ZoojaRDpZ1eSIh/EpzLNwlWuvzSZ3UbDFspjFvTDXe6e/g==",
       "dev": true,
       "engines": {
-        "node": ">=8"
+        "node": ">=12.20"
       }
     },
     "node_modules/detect-newline": {
@@ -10402,6 +10412,15 @@
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/standard-version/node_modules/detect-indent": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.1.0.tgz",
+      "integrity": "sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/standard-version/node_modules/yargs": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coveo/push-api-client",
-  "version": "2.7.12",
+  "version": "2.7.13",
   "description": "Push API client",
   "main": "./dist/index.js",
   "files": [
@@ -24,6 +24,7 @@
     "@typescript-eslint/eslint-plugin": "5.45.1",
     "@typescript-eslint/parser": "5.45.1",
     "cz-conventional-changelog": "3.3.0",
+    "detect-indent": "7.0.1",
     "dotenv": "16.0.3",
     "eslint": "8.29.0",
     "eslint-config-prettier": "8.5.0",
@@ -86,5 +87,10 @@
   "bugs": {
     "url": "https://github.com/coveo/push-api-client.js/issues"
   },
-  "homepage": "https://github.com/coveo/push-api-client.js#readme"
+  "homepage": "https://github.com/coveo/push-api-client.js#readme",
+  "standard-version": {
+    "scripts": {
+      "prebump": "node fixLock.mjs"
+    }
+  }
 }


### PR DESCRIPTION
This will ensure the error we see in renovate PR #233 doesn't happen again.
This is caused by `standard-version` not playing nice with the 'self-import' that we use for the sample.

This is a bit 🩹 but the other solution is a bit heavy handed: switch to semantic-monorepo-tools.

Will keep that for the move to coveo/sdk,js