### PR TITLE
fix: discard undefined security provider

### DIFF
--- a/src/securityIdentityBuilder.spec.ts
+++ b/src/securityIdentityBuilder.spec.ts
@@ -1,0 +1,61 @@
+import {
+  GroupSecurityIdentityBuilder,
+  VirtualGroupSecurityIdentityBuilder,
+  UserSecurityIdentityBuilder,
+} from './securityIdentityBuilder';
+
+describe('SecurityIdentityBuilder', () => {
+  describe('when instanciating a UserSecurityIdentityBuilder', () => {
+    it('should not include undefined securityProvider', () => {
+      const identity = new UserSecurityIdentityBuilder('foo@example.com');
+      expect(identity.build()).toEqual({
+        identity: 'foo@example.com',
+        identityType: 'USER',
+        securityProvider: 'Email Security Provider',
+      });
+    });
+
+    it('should not use provided securityProvider', () => {
+      const identity = new UserSecurityIdentityBuilder(
+        'foo@example.com',
+        'provider12345'
+      );
+      expect(identity.build()).toEqual({
+        identity: 'foo@example.com',
+        identityType: 'USER',
+        securityProvider: 'provider12345',
+      });
+    });
+  });
+
+  describe.each([
+    {identityBuilderClass: GroupSecurityIdentityBuilder, identityType: 'GROUP'},
+    {
+      identityBuilderClass: VirtualGroupSecurityIdentityBuilder,
+      identityType: 'VIRTUAL_GROUP',
+    },
+  ])(
+    'when instanciating a $identityBuilderClass.name',
+    ({identityBuilderClass, identityType}) => {
+      it('should not include undefined securityProvider', () => {
+        const identity = new identityBuilderClass('SampleTeam');
+        expect(identity.build()).toEqual({
+          identity: 'SampleTeam',
+          identityType,
+        });
+      });
+
+      it('should include securityProvider in the identity', () => {
+        const identity = new identityBuilderClass(
+          'SampleTeam',
+          'provider123456'
+        );
+        expect(identity.build()).toEqual({
+          identity: 'SampleTeam',
+          identityType,
+          securityProvider: 'provider123456',
+        });
+      });
+    }
+  );
+});

--- a/src/securityIdentityBuilder.ts
+++ b/src/securityIdentityBuilder.ts
@@ -31,7 +31,7 @@ export class AnySecurityIdentityBuilder implements SecurityIdentityBuilder {
     this.securityIdentity = {
       identityType,
       identity,
-      securityProvider,
+      ...(securityProvider && {securityProvider}),
     };
   }
 


### PR DESCRIPTION
When the security provider was not specified during the permission creation, the marshalled JSON sent to the API contained `undefined` as a value for the securityProvider.

[CDX](https://coveord.atlassian.net/browse/CDX-1276)
