### PR TITLE
chore: create `PermissionSetBuilder` class

### DIFF
--- a/samples/pushDocumentWithPermissions.ts
+++ b/samples/pushDocumentWithPermissions.ts
@@ -21,6 +21,7 @@ async function main() {
     'https://my.document.uri',
     'My document title'
   )
+    // TODO: CDX-??? use PermissionSetBuilder instead
     .withAllowAnonymousUsers(false)
     .withAllowedPermissions(allowedUsers)
     .withDeniedPermissions(deniedUsers);

--- a/samples/pushDocumentWithPermissions.ts
+++ b/samples/pushDocumentWithPermissions.ts
@@ -21,7 +21,7 @@ async function main() {
     'https://my.document.uri',
     'My document title'
   )
-    // TODO: CDX-??? use PermissionSetBuilder instead
+    // TODO: CDX-1278 use PermissionSetBuilder instead
     .withAllowAnonymousUsers(false)
     .withAllowedPermissions(allowedUsers)
     .withDeniedPermissions(deniedUsers);

--- a/src/__snapshots__/permissionSetBuilder.spec.ts.snap
+++ b/src/__snapshots__/permissionSetBuilder.spec.ts.snap
@@ -1,0 +1,110 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PermissionSetBuilder should marshal allowedPermissions in multiple #withAllowedPermissions 1`] = `
+{
+  "allowAnonymous": false,
+  "allowedPermissions": [
+    {
+      "identity": "max@foo.com",
+      "identityType": "USER",
+      "securityProvider": "Email Security Provider",
+    },
+    {
+      "identity": "sue@foo.com",
+      "identityType": "USER",
+      "securityProvider": "Email Security Provider",
+    },
+    {
+      "identity": "bob@foo.com",
+      "identityType": "USER",
+      "securityProvider": "Email Security Provider",
+    },
+    {
+      "identity": "SampleGroup",
+      "identityType": "VIRTUAL_GROUP",
+    },
+    {
+      "identity": "SpecialGroup",
+      "identityType": "VIRTUAL_GROUP",
+    },
+    {
+      "identity": "my_group",
+      "identityType": "GROUP",
+    },
+  ],
+  "deniedPermissions": [],
+}
+`;
+
+exports[`PermissionSetBuilder should marshal both allowed and denied permissions  1`] = `
+{
+  "allowAnonymous": false,
+  "allowedPermissions": [
+    {
+      "identity": "SampleGroup",
+      "identityType": "VIRTUAL_GROUP",
+    },
+    {
+      "identity": "SpecialGroup",
+      "identityType": "VIRTUAL_GROUP",
+    },
+    {
+      "identity": "my_group",
+      "identityType": "GROUP",
+    },
+  ],
+  "deniedPermissions": [
+    {
+      "identity": "max@foo.com",
+      "identityType": "USER",
+      "securityProvider": "Email Security Provider",
+    },
+    {
+      "identity": "sue@foo.com",
+      "identityType": "USER",
+      "securityProvider": "Email Security Provider",
+    },
+    {
+      "identity": "bob@foo.com",
+      "identityType": "USER",
+      "securityProvider": "Email Security Provider",
+    },
+  ],
+}
+`;
+
+exports[`PermissionSetBuilder should marshal deniedPermissions in multiple #withDeniedPermissions 1`] = `
+{
+  "allowAnonymous": false,
+  "allowedPermissions": [],
+  "deniedPermissions": [
+    {
+      "identity": "max@foo.com",
+      "identityType": "USER",
+      "securityProvider": "Email Security Provider",
+    },
+    {
+      "identity": "sue@foo.com",
+      "identityType": "USER",
+      "securityProvider": "Email Security Provider",
+    },
+    {
+      "identity": "bob@foo.com",
+      "identityType": "USER",
+      "securityProvider": "Email Security Provider",
+    },
+    {
+      "identity": "SampleGroup",
+      "identityType": "VIRTUAL_GROUP",
+    },
+    {
+      "identity": "SpecialGroup",
+      "identityType": "VIRTUAL_GROUP",
+    },
+    {
+      "identity": "my_group",
+      "identityType": "GROUP",
+    },
+  ],
+}
+`;

--- a/src/document.ts
+++ b/src/document.ts
@@ -170,7 +170,7 @@ export interface Document {
    *
    * See https://docs.coveo.com/en/107 for more information.
    */
-  // TODO: CDX-??? support simple and complex permission sets Array<PermissionSetModel | PermissionLevelModel>;
+  // TODO: CDX-1278 support simple and complex permission sets Array<PermissionSetModel | PermissionLevelModel>;
   permissions?: {
     /**
      * Whether to allow anonymous users in this permission set.

--- a/src/document.ts
+++ b/src/document.ts
@@ -48,6 +48,26 @@ export type CompressionType =
   | 'LZMA'
   | 'ZLIB';
 
+export type PermissionSetModel = {
+  /**
+   * Whether to allow anonymous users in this permission set.
+   */
+  allowAnonymous: boolean;
+  /**
+   * The list of allowed permissions for this permission set.
+   */
+  allowedPermissions?: SecurityIdentity[];
+  /**
+   * The list of denied permissions for this permission set.
+   */
+  deniedPermissions?: SecurityIdentity[];
+};
+
+export type PermissionLevelModel = {
+  name: string;
+  permissionSets: PermissionSetModel[];
+};
+
 /**
  * A Coveo document.
  */
@@ -150,6 +170,7 @@ export interface Document {
    *
    * See https://docs.coveo.com/en/107 for more information.
    */
+  // TODO: CDX-??? support simple and complex permission sets Array<PermissionSetModel | PermissionLevelModel>;
   permissions?: {
     /**
      * Whether to allow anonymous users in this permission set.

--- a/src/documentBuilder.ts
+++ b/src/documentBuilder.ts
@@ -211,7 +211,7 @@ export class DocumentBuilder {
    * @returns
    */
   public withAllowedPermissions(
-    // TODO: CDX-??? use PermissionSetBuilder instead
+    // TODO: CDX-1278 use PermissionSetBuilder instead
     securityIdentityBuilder: SecurityIdentityBuilder
   ) {
     this.setPermission(securityIdentityBuilder, 'allowedPermissions');
@@ -224,7 +224,7 @@ export class DocumentBuilder {
    * @returns
    */
   public withDeniedPermissions(
-    // TODO: CDX-??? use PermissionSetBuilder instead
+    // TODO: CDX-1278 use PermissionSetBuilder instead
     securityIdentityBuilder: SecurityIdentityBuilder
   ) {
     this.setPermission(securityIdentityBuilder, 'deniedPermissions');
@@ -237,7 +237,7 @@ export class DocumentBuilder {
    * @returns
    */
   public withAllowAnonymousUsers(allowAnonymous: boolean) {
-    // TODO: CDX-??? use PermissionSetBuilder instead
+    // TODO: CDX-1278 use PermissionSetBuilder instead
     this.doc.permissions!.allowAnonymous = allowAnonymous;
     return this;
   }

--- a/src/documentBuilder.ts
+++ b/src/documentBuilder.ts
@@ -211,6 +211,7 @@ export class DocumentBuilder {
    * @returns
    */
   public withAllowedPermissions(
+    // TODO: CDX-??? use PermissionSetBuilder instead
     securityIdentityBuilder: SecurityIdentityBuilder
   ) {
     this.setPermission(securityIdentityBuilder, 'allowedPermissions');
@@ -223,6 +224,7 @@ export class DocumentBuilder {
    * @returns
    */
   public withDeniedPermissions(
+    // TODO: CDX-??? use PermissionSetBuilder instead
     securityIdentityBuilder: SecurityIdentityBuilder
   ) {
     this.setPermission(securityIdentityBuilder, 'deniedPermissions');
@@ -235,6 +237,7 @@ export class DocumentBuilder {
    * @returns
    */
   public withAllowAnonymousUsers(allowAnonymous: boolean) {
+    // TODO: CDX-??? use PermissionSetBuilder instead
     this.doc.permissions!.allowAnonymous = allowAnonymous;
     return this;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,5 +18,6 @@ export {DocumentBuilder} from './documentBuilder';
 export * from './securityIdentityBuilder';
 export {PlatformEnvironment, Region, PlatformUrlOptions} from './environment';
 export {SourceVisibility} from '@coveo/platform-client';
+export {PermissionSetBuilder} from './permissionSetBuilder';
 
 export {parseAndGetDocumentBuilderFromJSONDocument} from './validation/parseFile';

--- a/src/permissionSetBuilder.spec.ts
+++ b/src/permissionSetBuilder.spec.ts
@@ -1,0 +1,90 @@
+import {PermissionSetBuilder} from './permissionSetBuilder';
+import {
+  GroupSecurityIdentityBuilder,
+  UserSecurityIdentityBuilder,
+  VirtualGroupSecurityIdentityBuilder,
+} from './securityIdentityBuilder';
+
+describe('PermissionSetBuilder', () => {
+  const bobUserIdentity = new UserSecurityIdentityBuilder('bob@foo.com');
+  const multipleUsersIdentity = new UserSecurityIdentityBuilder([
+    'max@foo.com',
+    'sue@foo.com',
+  ]);
+  const groupIdentity = new GroupSecurityIdentityBuilder('my_group');
+  const virtualGroupsIdentity = new VirtualGroupSecurityIdentityBuilder([
+    'SampleGroup',
+    'SpecialGroup',
+  ]);
+  let restrictedPermissionSet: PermissionSetBuilder;
+  let openedPermissionSet: PermissionSetBuilder;
+
+  beforeEach(() => {
+    restrictedPermissionSet = new PermissionSetBuilder(false);
+    openedPermissionSet = new PermissionSetBuilder(true);
+  });
+
+  it('should marshal allowAnonymous to false', () => {
+    expect(restrictedPermissionSet.build()).toEqual(
+      expect.objectContaining({allowAnonymous: false})
+    );
+  });
+
+  it('should marshal allowAnonymous to true', () => {
+    expect(openedPermissionSet.build()).toEqual(
+      expect.objectContaining({allowAnonymous: true})
+    );
+  });
+
+  it('should marshal allowedPermissions', () => {
+    restrictedPermissionSet.withAllowedPermissions(bobUserIdentity);
+
+    expect(restrictedPermissionSet.build()).toMatchObject({
+      allowedPermissions: expect.arrayContaining([
+        expect.objectContaining({identity: 'bob@foo.com'}),
+      ]),
+    });
+  });
+
+  it('should marshal allowedPermissions in multiple #withAllowedPermissions', () => {
+    restrictedPermissionSet
+      .withAllowedPermissions(multipleUsersIdentity)
+      .withAllowedPermissions(bobUserIdentity)
+      .withAllowedPermissions(virtualGroupsIdentity)
+      .withAllowedPermissions(groupIdentity);
+
+    expect(restrictedPermissionSet.build()).toMatchSnapshot();
+  });
+
+  it('should marshal deniedPermissions', () => {
+    restrictedPermissionSet.withDeniedPermissions(
+      new UserSecurityIdentityBuilder('bob@foo.com')
+    );
+
+    expect(restrictedPermissionSet.build()).toMatchObject({
+      deniedPermissions: expect.arrayContaining([
+        expect.objectContaining({identity: 'bob@foo.com'}),
+      ]),
+    });
+  });
+
+  it('should marshal deniedPermissions in multiple #withDeniedPermissions', () => {
+    restrictedPermissionSet
+      .withDeniedPermissions(multipleUsersIdentity)
+      .withDeniedPermissions(bobUserIdentity)
+      .withDeniedPermissions(virtualGroupsIdentity)
+      .withDeniedPermissions(groupIdentity);
+
+    expect(restrictedPermissionSet.build()).toMatchSnapshot();
+  });
+
+  it('should marshal both allowed and denied permissions ', () => {
+    restrictedPermissionSet
+      .withDeniedPermissions(multipleUsersIdentity)
+      .withDeniedPermissions(bobUserIdentity)
+      .withAllowedPermissions(virtualGroupsIdentity)
+      .withAllowedPermissions(groupIdentity);
+
+    expect(restrictedPermissionSet.build()).toMatchSnapshot();
+  });
+});

--- a/src/permissionSetBuilder.ts
+++ b/src/permissionSetBuilder.ts
@@ -1,0 +1,73 @@
+import {PermissionSetModel} from './document';
+import {SecurityIdentityBuilder} from './securityIdentityBuilder';
+
+type PermissionSection = keyof Pick<
+  PermissionSetModel,
+  'allowedPermissions' | 'deniedPermissions'
+>;
+
+export class PermissionSetBuilder {
+  private permissionSet: PermissionSetModel;
+
+  /**
+   * Builds a Permission Set Model
+   *
+   * See[Simple Permission Model Definition](https://docs.coveo.com/en/107/index-content/simple-permission-model-definition-examples)
+   * @param {boolean} allowAnonymous Whether to allow anonymous users in this permission set
+   */
+  public constructor(allowAnonymous: boolean) {
+    this.permissionSet = {
+      allowAnonymous,
+      allowedPermissions: [],
+      deniedPermissions: [],
+    };
+  }
+
+  /**
+   * Set allowed identities on the document. See {@link PermissionSetModel}
+   *
+   * When the {@link PermissionsSetBuilder} class is instanciated with `allowAnonymous` property set to `true`, calling this method is redundant, and can therefore be omitted.
+   * @param securityIdentityBuilder The allowed security identities to add to the permission set
+   * @returns
+   */
+  public withAllowedPermissions(
+    securityIdentityBuilder: SecurityIdentityBuilder
+  ) {
+    this.setPermission(securityIdentityBuilder, 'allowedPermissions');
+    return this;
+  }
+
+  /**
+   * Set denied identities on the document. See {@link PermissionSetModel}
+   *
+   * @param securityIdentityBuilder The denied security identities to add to the permission set
+   * @returns
+   */
+  public withDeniedPermissions(
+    securityIdentityBuilder: SecurityIdentityBuilder
+  ) {
+    this.setPermission(securityIdentityBuilder, 'deniedPermissions');
+    return this;
+  }
+
+  /**
+   * Build and return the security identity or identities.
+   * @returns
+   */
+  public build(): PermissionSetModel {
+    return this.permissionSet;
+  }
+
+  private setPermission(
+    securityIdentityBuilder: SecurityIdentityBuilder,
+    permissionSection: PermissionSection
+  ) {
+    const identities = securityIdentityBuilder.build();
+    if (Array.isArray(identities)) {
+      this.permissionSet[permissionSection] =
+        this.permissionSet[permissionSection]?.concat(identities);
+    } else {
+      this.permissionSet[permissionSection]?.push(identities);
+    }
+  }
+}

--- a/src/securityIdentityBuilder.spec.ts
+++ b/src/securityIdentityBuilder.spec.ts
@@ -1,0 +1,61 @@
+import {
+  GroupSecurityIdentityBuilder,
+  VirtualGroupSecurityIdentityBuilder,
+  UserSecurityIdentityBuilder,
+} from './securityIdentityBuilder';
+
+describe('SecurityIdentityBuilder', () => {
+  describe('when instanciating a UserSecurityIdentityBuilder', () => {
+    it('should not include undefined securityProvider', () => {
+      const identity = new UserSecurityIdentityBuilder('foo@example.com');
+      expect(identity.build()).toEqual({
+        identity: 'foo@example.com',
+        identityType: 'USER',
+        securityProvider: 'Email Security Provider',
+      });
+    });
+
+    it('should not use provided securityProvider', () => {
+      const identity = new UserSecurityIdentityBuilder(
+        'foo@example.com',
+        'provider12345'
+      );
+      expect(identity.build()).toEqual({
+        identity: 'foo@example.com',
+        identityType: 'USER',
+        securityProvider: 'provider12345',
+      });
+    });
+  });
+
+  describe.each([
+    {identityBuilderClass: GroupSecurityIdentityBuilder, identityType: 'GROUP'},
+    {
+      identityBuilderClass: VirtualGroupSecurityIdentityBuilder,
+      identityType: 'VIRTUAL_GROUP',
+    },
+  ])(
+    'when instanciating a $identityBuilderClass.name',
+    ({identityBuilderClass, identityType}) => {
+      it('should not include undefined securityProvider', () => {
+        const identity = new identityBuilderClass('SampleTeam');
+        expect(identity.build()).toEqual({
+          identity: 'SampleTeam',
+          identityType,
+        });
+      });
+
+      it('should include securityProvider in the identity', () => {
+        const identity = new identityBuilderClass(
+          'SampleTeam',
+          'provider123456'
+        );
+        expect(identity.build()).toEqual({
+          identity: 'SampleTeam',
+          identityType,
+          securityProvider: 'provider123456',
+        });
+      });
+    }
+  );
+});

--- a/src/securityIdentityBuilder.ts
+++ b/src/securityIdentityBuilder.ts
@@ -31,7 +31,7 @@ export class AnySecurityIdentityBuilder implements SecurityIdentityBuilder {
     this.securityIdentity = {
       identityType,
       identity,
-      securityProvider,
+      ...(securityProvider && {securityProvider}),
     };
   }
 


### PR DESCRIPTION
Create a Builder class to define document permissions. This class will be utilized in CDX-1278 **(TODO: add PR link)**.

Simply adding allowed and denied securities to the document is not enough to support the permission models supported by the API.

- [Simple Permission Model Definition Examples](https://docs.coveo.com/en/107/index-content/simple-permission-model-definition-examples).
- [Complex Permission Model Definition Example](https://docs.coveo.com/en/25/index-content/complex-permission-model-definition-example)