### PR TITLE
BREAKING CHANGE: `PermissionSetBuilder` should now be used for document permissions

### DIFF
--- a/src/__snapshots__/documentBuilder.spec.ts.snap
+++ b/src/__snapshots__/documentBuilder.spec.ts.snap
@@ -10,7 +10,6 @@ Field names can only contain lowercase letters (a-z), numbers (0-9), and undersc
     "
 `;
 
-
 exports[`DocumentBuilder should throw error for invalid metadata values even after transformation 1`] = `
 "
 The following field names are still invalid after transformation:
@@ -19,4 +18,61 @@ The following field names are still invalid after transformation:
 
 Field names can only contain lowercase letters (a-z), numbers (0-9), and underscores. Field names must be at least one character long and must start with a lowercase letter.
     "
+`;
+
+exports[`DocumentBuilder when combining multiple permission sets should marshal permission level 1`] = `
+[
+  {
+    "name": "level1",
+    "permissionSets": [
+      {
+        "allowAnonymous": true,
+        "allowedPermissions": [],
+        "deniedPermissions": [
+          {
+            "identity": "asmith@example.com",
+            "identityType": "USER",
+            "securityProvider": "Email Security Provider",
+          },
+        ],
+      },
+      {
+        "allowAnonymous": false,
+        "allowedPermissions": [
+          {
+            "identity": "SampleTeam1",
+            "identityType": "GROUP",
+          },
+          {
+            "identity": "emitchell@example.com",
+            "identityType": "USER",
+            "securityProvider": "Email Security Provider",
+          },
+        ],
+        "deniedPermissions": [],
+      },
+    ],
+  },
+  {
+    "name": "level2",
+    "permissionSets": [
+      {
+        "allowAnonymous": false,
+        "allowedPermissions": [
+          {
+            "identity": "MysteryUserX",
+            "identityType": "USER",
+            "securityProvider": "Email Security Provider",
+          },
+        ],
+        "deniedPermissions": [
+          {
+            "identity": "SampleGroup",
+            "identityType": "VIRTUAL_GROUP",
+          },
+        ],
+      },
+    ],
+  },
+]
 `;

--- a/src/__stub__/jsondocuments/identityAllowAnonymousNotABoolean.json
+++ b/src/__stub__/jsondocuments/identityAllowAnonymousNotABoolean.json
@@ -1,14 +1,16 @@
 {
   "DocumentId": "https://www.themoviedb.org/movie/550",
   "title": "Fight Club",
-  "permissions": {
-    "allowAnonymous": 123123,
-    "allowedPermissions": [
-      {
-        "identity": "bob@foo.com",
-        "identityType": "USER",
-        "securityProvider": "Email Security Provider"
-      }
-    ]
-  }
+  "permissions": [
+    {
+      "allowAnonymous": 123123,
+      "allowedPermissions": [
+        {
+          "identity": "bob@foo.com",
+          "identityType": "USER",
+          "securityProvider": "Email Security Provider"
+        }
+      ]
+    }
+  ]
 }

--- a/src/__stub__/jsondocuments/identityNotAString.json
+++ b/src/__stub__/jsondocuments/identityNotAString.json
@@ -1,14 +1,16 @@
 {
   "DocumentId": "https://www.themoviedb.org/movie/550",
   "title": "Fight Club",
-  "permissions": {
-    "allowAnonymous": false,
-    "allowedPermissions": [
-      {
-        "identity": 123123,
-        "identityType": "USER",
-        "securityProvider": "Email Security Provider"
-      }
-    ]
-  }
+  "permissions": [
+    {
+      "allowAnonymous": false,
+      "allowedPermissions": [
+        {
+          "identity": 123123,
+          "identityType": "USER",
+          "securityProvider": "Email Security Provider"
+        }
+      ]
+    }
+  ]
 }

--- a/src/__stub__/jsondocuments/identityTypeInvalidValue.json
+++ b/src/__stub__/jsondocuments/identityTypeInvalidValue.json
@@ -1,14 +1,16 @@
 {
   "DocumentId": "https://www.themoviedb.org/movie/550",
   "title": "Fight Club",
-  "permissions": {
-    "allowAnonymous": false,
-    "allowedPermissions": [
-      {
-        "identity": "bob@foo.com",
-        "identityType": "BAD_VALUE",
-        "securityProvider": "Email Security Provider"
-      }
-    ]
-  }
+  "permissions": [
+    {
+      "allowAnonymous": false,
+      "allowedPermissions": [
+        {
+          "identity": "bob@foo.com",
+          "identityType": "BAD_VALUE",
+          "securityProvider": "Email Security Provider"
+        }
+      ]
+    }
+  ]
 }

--- a/src/__stub__/jsondocuments/noIdentity.json
+++ b/src/__stub__/jsondocuments/noIdentity.json
@@ -1,10 +1,15 @@
 {
   "DocumentId": "https://www.themoviedb.org/movie/550",
   "title": "Fight Club",
-  "permissions": {
-    "allowAnonymous": false,
-    "allowedPermissions": [
-      {"identityType": "USER", "securityProvider": "Email Security Provider"}
-    ]
-  }
+  "permissions": [
+    {
+      "allowAnonymous": false,
+      "allowedPermissions": [
+        {
+          "identityType": "USER",
+          "securityProvider": "Email Security Provider"
+        }
+      ]
+    }
+  ]
 }

--- a/src/__stub__/jsondocuments/notAPermissionArray.json
+++ b/src/__stub__/jsondocuments/notAPermissionArray.json
@@ -1,0 +1,14 @@
+{
+    "DocumentId": "https://www.themoviedb.org/movie/550",
+    "title": "Fight Club",
+    "permissions": {
+        "allowAnonymous": false,
+        "allowedPermissions": [
+            {
+                "identity": "foo@email.com",
+                "identityType": "USER",
+                "securityProvider": "Email Security Provider"
+            }
+        ]
+    }
+}

--- a/src/document.ts
+++ b/src/document.ts
@@ -170,23 +170,7 @@ export interface Document {
    *
    * See https://docs.coveo.com/en/107 for more information.
    */
-  // TODO: CDX-1278 support simple and complex permission sets Array<PermissionSetModel | PermissionLevelModel>;
-  permissions?: {
-    /**
-     * Whether to allow anonymous users in this permission set.
-     *
-     * Default value is false.
-     */
-    allowAnonymous: boolean;
-    /**
-     * The list of allowed permissions for this permission set.
-     */
-    allowedPermissions?: SecurityIdentity[];
-    /**
-     * The list of denied permissions for this permission set.
-     */
-    deniedPermissions?: SecurityIdentity[];
-  };
+  permissions?: Array<PermissionSetModel | PermissionLevelModel>;
   /**
    * The file extension of the data you're pushing.
    *

--- a/src/documentBuilder.spec.ts
+++ b/src/documentBuilder.spec.ts
@@ -1,7 +1,9 @@
 import {DocumentBuilder} from './documentBuilder';
+import {PermissionSetBuilder} from './permissionSetBuilder';
 import {
   GroupSecurityIdentityBuilder,
   UserSecurityIdentityBuilder,
+  VirtualGroupSecurityIdentityBuilder,
 } from './securityIdentityBuilder';
 import {BuiltInTransformers} from './validation/transformers/transformer';
 
@@ -169,109 +171,84 @@ describe('DocumentBuilder', () => {
     expect(() => docBuilder.withFileExtension('nope')).toThrow();
   });
 
-  it('should marshal allowedPermissions', () => {
-    expect(
-      docBuilder
-        .withAllowedPermissions(new UserSecurityIdentityBuilder('bob@foo.com'))
-        .marshal().permissions![0]
-    ).toMatchObject({
-      allowedPermissions: expect.arrayContaining([
-        expect.objectContaining({identity: 'bob@foo.com'}),
-      ]),
-    });
+  it('should build every permission set added to the document', () => {
+    const userIdentity = new UserSecurityIdentityBuilder([
+      'bob@foo.com',
+      'sue@foo.com',
+    ]);
+    const groupIdentity = new GroupSecurityIdentityBuilder('my_group');
+    const bobSpy = jest.spyOn(userIdentity, 'build');
+    const groupSpy = jest.spyOn(userIdentity, 'build');
+
+    const permissionSet = new PermissionSetBuilder(false)
+      .withDeniedPermissions(userIdentity)
+      .withDeniedPermissions(groupIdentity);
+
+    docBuilder.withPermissionSet(permissionSet);
+
+    expect(bobSpy).toHaveBeenCalledTimes(1);
+    expect(groupSpy).toHaveBeenCalledTimes(1);
   });
 
-  it('should marshal allowedPermissions in multiple #withAllowedPermissions', () => {
-    expect(
-      docBuilder
-        .withAllowedPermissions(new UserSecurityIdentityBuilder('bob@foo.com'))
-        .withAllowedPermissions(new GroupSecurityIdentityBuilder('my_group'))
-        .marshal().permissions![0]
-    ).toMatchObject({
-      allowedPermissions: expect.arrayContaining([
-        expect.objectContaining({
-          identity: 'bob@foo.com',
-          identityType: 'USER',
-        }),
-        expect.objectContaining({
-          identity: 'my_group',
-          identityType: 'GROUP',
-        }),
-      ]),
-    });
+  it('should marshal an empty array when permissions are not defined', () => {
+    expect(docBuilder.marshal().permissions).toHaveLength(0);
   });
 
-  it('should marshal multiple allowedPermissions', () => {
-    expect(
-      docBuilder
-        .withAllowedPermissions(
-          new UserSecurityIdentityBuilder(['bob@foo.com', 'sue@foo.com'])
-        )
-        .marshal().permissions![0]
-    ).toMatchObject({
-      allowedPermissions: expect.arrayContaining([
-        expect.objectContaining({identity: 'bob@foo.com'}),
-        expect.objectContaining({identity: 'sue@foo.com'}),
-      ]),
-    });
+  it('should marshal permission set', () => {
+    const userIdentity = new UserSecurityIdentityBuilder([
+      'bob@foo.com',
+      'sue@foo.com',
+    ]);
+    const permissionSet = new PermissionSetBuilder(false)
+      .withDeniedPermissions(userIdentity)
+      .withDeniedPermissions(new GroupSecurityIdentityBuilder('my_group'))
+      .withDeniedPermissions(
+        new VirtualGroupSecurityIdentityBuilder('virtual_group')
+      );
+
+    const {permissions} = docBuilder.withPermissionSet(permissionSet).marshal();
+    expect(permissions).toHaveLength(1);
   });
 
-  it('should marshal deniedPermissions', () => {
-    expect(
-      docBuilder
-        .withDeniedPermissions(new UserSecurityIdentityBuilder('bob@foo.com'))
-        .marshal().permissions![0]
-    ).toMatchObject({
-      deniedPermissions: expect.arrayContaining([
-        expect.objectContaining({identity: 'bob@foo.com'}),
-      ]),
-    });
-  });
-
-  it('should marshal deniedPermissions in multiple #withDeniedPermissions', () => {
-    expect(
-      docBuilder
-        .withDeniedPermissions(new UserSecurityIdentityBuilder('bob@foo.com'))
-        .withDeniedPermissions(new GroupSecurityIdentityBuilder('my_group'))
-        .marshal().permissions![0]
-    ).toMatchObject({
-      deniedPermissions: expect.arrayContaining([
-        expect.objectContaining({
-          identity: 'bob@foo.com',
-          identityType: 'USER',
-        }),
-        expect.objectContaining({
-          identity: 'my_group',
-          identityType: 'GROUP',
-        }),
-      ]),
-    });
-  });
-
-  it('should marshal multiple deniedPermissions', () => {
-    expect(
-      docBuilder
-        .withDeniedPermissions(
-          new UserSecurityIdentityBuilder(['bob@foo.com', 'sue@foo.com'])
-        )
-        .marshal().permissions![0]
-    ).toMatchObject({
-      deniedPermissions: expect.arrayContaining([
-        expect.objectContaining({identity: 'bob@foo.com'}),
-        expect.objectContaining({identity: 'sue@foo.com'}),
-      ]),
-    });
-  });
-
-  it('should marshal allowedPermissions to an empty array when undefined', () => {
-    expect(docBuilder.marshal().permissions![0].allowedPermissions.length).toBe(
-      0
+  describe('when combining multiple permission sets', () => {
+    // Example taken from https://docs.coveo.com/en/107
+    const openedPermissionSet = new PermissionSetBuilder(
+      true
+    ).withDeniedPermissions(
+      new UserSecurityIdentityBuilder('asmith@example.com')
     );
-  });
 
-  it('should marshal deniedPermissions to an empty array when undefined', () => {
-    expect(docBuilder.marshal().permissions![0].deniedPermissions.length).toBe(
-      0
-    );
+    const restrictedPermissionSet = new PermissionSetBuilder(false)
+      .withAllowedPermissions(new GroupSecurityIdentityBuilder('SampleTeam1'))
+      .withAllowedPermissions(
+        new UserSecurityIdentityBuilder('emitchell@example.com')
+      );
+
+    const misteryPermissionSet = new PermissionSetBuilder(false)
+      .withDeniedPermissions(
+        new VirtualGroupSecurityIdentityBuilder('SampleGroup')
+      )
+      .withAllowedPermissions(new UserSecurityIdentityBuilder('MysteryUserX'));
+
+    it('should marshal multiple permission sets', () => {
+      const {permissions} = docBuilder
+        .withPermissionSet(openedPermissionSet)
+        .withPermissionSet(restrictedPermissionSet)
+        .withPermissionSet(misteryPermissionSet)
+        .marshal();
+      expect(permissions).toHaveLength(3);
+    });
+
+    it('should marshal permission level', () => {
+      const {permissions} = docBuilder
+        .withPermissionLevel('level1', [
+          openedPermissionSet,
+          restrictedPermissionSet,
+        ])
+        .withPermissionLevel('level2', [misteryPermissionSet])
+        .marshal();
+
+      expect(permissions).toMatchSnapshot();
+    });
   });
 });

--- a/src/validation/knownKey.ts
+++ b/src/validation/knownKey.ts
@@ -25,9 +25,19 @@ export class KnownKeys<T extends PrimitivesValues> {
     return null;
   }
 
-  public whenExists(cb: (v: T) => void) {
-    if (!isNullOrUndefined(this.value)) {
-      cb(this.value as T);
+  public whenExists<U = T>(cb: (v: U) => void) {
+    const value = this.value;
+    if (!isNullOrUndefined(value)) {
+      cb(value as U);
     }
+    return this;
+  }
+
+  public whenDoesNotExist<U = T>(cb: (v: U) => void) {
+    const value = this.value;
+    if (isNullOrUndefined(value)) {
+      cb(this.doc.documentRecord as U);
+    }
+    return this;
   }
 }

--- a/src/validation/parseFile.spec.ts
+++ b/src/validation/parseFile.spec.ts
@@ -47,6 +47,11 @@ describe('parseFile', () => {
       error:
         'allowedpermissions:   value should be one of: UNKNOWN, USER, GROUP, VIRTUAL_GROUP.',
     },
+    {
+      title: 'should fail on permission not being an array',
+      fileName: 'notAPermissionArray.json',
+      error: 'permissions: value is not an array',
+    },
   ])('$title', async ({fileName, error}) => {
     const file = join(pathToStub, 'jsondocuments', fileName);
     await expect(parse(file)).rejects.toThrow(

--- a/src/validation/parseFile.ts
+++ b/src/validation/parseFile.ts
@@ -21,8 +21,9 @@ import {
   NotAJsonFileError,
 } from '../errors/validatorErrors';
 import {RequiredKeyValidator} from './requiredKeyValidator';
-import {Metadata} from '../document';
+import {Metadata, PermissionLevelModel, PermissionSetModel} from '../document';
 import {ParseDocumentOptions} from '../interfaces';
+import {PermissionSetBuilder} from '../permissionSetBuilder';
 
 export const parseAndGetDocumentBuilderFromJSONDocument = async (
   documentPath: PathLike,
@@ -77,11 +78,7 @@ const processDocument = (
   );
   try {
     processKnownKeys(caseInsensitiveDoc, documentBuilder);
-    processSecurityIdentities(
-      caseInsensitiveDoc,
-      documentBuilder,
-      documentPath
-    );
+    processPermissionList(caseInsensitiveDoc, documentBuilder, documentPath);
     processMetadata(caseInsensitiveDoc, documentBuilder, options);
   } catch (error) {
     if (typeof error === 'string') {
@@ -167,78 +164,160 @@ const processKnownKeys = (
   );
 };
 
-const processSecurityIdentities = (
+const ensurePermissionArray = (
+  caseInsensitiveDoc: CaseInsensitiveDocument<PrimitivesValues>,
+  documentPath: PathLike
+) => {
+  const requiredPermissionArray = new RequiredKeyValidator(
+    'permissions',
+    caseInsensitiveDoc,
+    new ArrayValue({required: false})
+  );
+  if (!requiredPermissionArray.isValid) {
+    throw new InvalidDocument(
+      documentPath,
+      requiredPermissionArray.explanation
+    );
+  }
+};
+
+const processPermissionList = (
   caseInsensitiveDoc: CaseInsensitiveDocument<PrimitivesValues>,
   documentBuilder: DocumentBuilder,
   documentPath: PathLike
 ) => {
+  ensurePermissionArray(caseInsensitiveDoc, documentPath);
   new KnownKeys<Document['permissions']>(
     'permissions',
     caseInsensitiveDoc
   ).whenExists((permissions) => {
-    const caseInsensitivePermissions = new CaseInsensitiveDocument(
-      permissions!
-    );
-    const requiredAllowAnonymous = new RequiredKeyValidator(
-      'allowanonymous',
-      caseInsensitivePermissions,
-      new BooleanValue({required: true})
-    );
-    if (!requiredAllowAnonymous.isValid) {
-      throw new InvalidDocument(
-        documentPath,
-        requiredAllowAnonymous.explanation
-      );
-    }
+    permissions!.forEach((permission) => {
+      const caseInsensitivePermission =
+        new CaseInsensitiveDocument<PrimitivesValues>(permission);
 
-    const requiredAllowedPermissions = new RequiredKeyValidator(
-      'allowedpermissions',
-      caseInsensitivePermissions,
-      getSecurityIdentitySchemaValidation()
-    );
-
-    if (!requiredAllowedPermissions.isValid) {
-      throw new InvalidDocument(
-        documentPath,
-        requiredAllowedPermissions.explanation
-      );
-    }
-
-    const requiredDeniedPermissions = new RequiredKeyValidator(
-      'deniedpermissions',
-      caseInsensitivePermissions,
-      getSecurityIdentitySchemaValidation()
-    );
-
-    if (!requiredDeniedPermissions.isValid) {
-      throw new InvalidDocument(
-        documentPath,
-        requiredDeniedPermissions.explanation
-      );
-    }
-
-    documentBuilder.withAllowAnonymousUsers(permissions!.allowAnonymous);
-    permissions?.allowedPermissions?.forEach((p) => {
-      documentBuilder.withAllowedPermissions(
-        new AnySecurityIdentityBuilder(
-          p.identityType,
-          p.identity,
-          p.securityProvider
+      new KnownKeys('permissionsets', caseInsensitivePermission)
+        .whenExists<PermissionLevelModel>((permissionLevel) =>
+          processPermissionLevel(permissionLevel, documentBuilder, documentPath)
         )
-      );
-    });
-    permissions?.deniedPermissions?.forEach((p) => {
-      documentBuilder.withDeniedPermissions(
-        new AnySecurityIdentityBuilder(
-          p.identityType,
-          p.identity,
-          p.securityProvider
-        )
-      );
+        .whenDoesNotExist<PermissionSetModel>((permissionSet) =>
+          processPermissionSet(permissionSet, documentBuilder, documentPath)
+        );
     });
 
     delete caseInsensitiveDoc.documentRecord['permissions'];
   });
+};
+
+const processPermissionSet = (
+  permissionSet: PermissionSetModel,
+  documentBuilder: DocumentBuilder,
+  documentPath: PathLike
+) => {
+  const permissionSetBuilder =
+    validateRequiredPermissionSetKeysAndGetPermissionSetBuilder(
+      permissionSet,
+      documentPath
+    );
+
+  documentBuilder.withPermissionSet(permissionSetBuilder);
+};
+
+const processPermissionLevel = (
+  permission: PermissionLevelModel,
+  documentBuilder: DocumentBuilder,
+  documentPath: PathLike
+) => {
+  const permissionSetBuilders = permission.permissionSets.map(
+    (permissionSet) => {
+      const caseInsensitivePermissions = new CaseInsensitiveDocument(
+        permission
+      );
+      const requiredPermissionLevelName = new RequiredKeyValidator<string>(
+        'name',
+        caseInsensitivePermissions,
+        new StringValue({required: true, emptyAllowed: false})
+      );
+      if (!requiredPermissionLevelName.isValid) {
+        throw new InvalidDocument(
+          documentPath,
+          requiredPermissionLevelName.explanation
+        );
+      }
+      return validateRequiredPermissionSetKeysAndGetPermissionSetBuilder(
+        permissionSet,
+        documentPath
+      );
+    }
+  );
+
+  documentBuilder.withPermissionLevel(permission.name, permissionSetBuilders);
+};
+
+const validateRequiredPermissionSetKeysAndGetPermissionSetBuilder = (
+  permission: PermissionSetModel,
+  documentPath: PathLike
+): PermissionSetBuilder => {
+  const caseInsensitivePermissions = new CaseInsensitiveDocument(permission);
+  const requiredAllowAnonymous = new RequiredKeyValidator(
+    'allowanonymous',
+    caseInsensitivePermissions,
+    new BooleanValue({required: true})
+  );
+  if (!requiredAllowAnonymous.isValid) {
+    throw new InvalidDocument(documentPath, requiredAllowAnonymous.explanation);
+  }
+
+  const requiredAllowedPermissions = new RequiredKeyValidator(
+    'allowedpermissions',
+    caseInsensitivePermissions,
+    getSecurityIdentitySchemaValidation()
+  );
+
+  if (!requiredAllowedPermissions.isValid) {
+    throw new InvalidDocument(
+      documentPath,
+      requiredAllowedPermissions.explanation
+    );
+  }
+
+  const requiredDeniedPermissions = new RequiredKeyValidator(
+    'deniedpermissions',
+    caseInsensitivePermissions,
+    getSecurityIdentitySchemaValidation()
+  );
+
+  if (!requiredDeniedPermissions.isValid) {
+    throw new InvalidDocument(
+      documentPath,
+      requiredDeniedPermissions.explanation
+    );
+  }
+
+  const permissionSetBuilder = new PermissionSetBuilder(
+    permission.allowAnonymous
+  );
+
+  permission.allowedPermissions?.forEach((p) => {
+    permissionSetBuilder.withAllowedPermissions(
+      new AnySecurityIdentityBuilder(
+        p.identityType,
+        p.identity,
+        p.securityProvider
+      )
+    );
+  });
+
+  permission.deniedPermissions?.forEach((p) => {
+    permissionSetBuilder.withDeniedPermissions(
+      new AnySecurityIdentityBuilder(
+        p.identityType,
+        p.identity,
+        p.securityProvider
+      )
+    );
+  });
+
+  return permissionSetBuilder;
 };
 
 const processMetadata = (


### PR DESCRIPTION
`DocumentBuilder` now expects a `PermissionSetBuilder` instance containing the information on the security identities.

Initially it was not possible to provide more than one permission set on a single document.

It is also possible to define permission sets (simple use case) as well as permissions levels (for complex permission hierarchy).

For more information on the permission concepts, visit:
- [Simple Permission Model Definition Examples](https://docs.coveo.com/en/107/index-content/simple-permission-model-definition-examples).
- [Complex Permission Model Definition Example](https://docs.coveo.com/en/25/index-content/complex-permission-model-definition-example)
