### PR TITLE
CSEC-18897 bump peaceiris/actions-gh-pages to 3.9 via hash

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Deploy doc
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@bd8c6b06eba6b3d25d72b7a1767993c0aeee42e7
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./dist/docs


### PR DESCRIPTION
Bump actions-gh-pages to specific 3.9 hash to comply with CSEC's policies on GHAs
https://coveord.atlassian.net/browse/CSEC-18897