### PR TITLE
chore: do not npm publish directly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Test
         run: npm run test
       - name: Release
-        run: npm publish
+        run: npm run release
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -77,8 +77,7 @@
     "prettier:check": "prettier .",
     "prettier:fix": "prettier --write .",
     "commit": "git-cz",
-    "release": "node release.mjs",
-    "prepublishOnly": "npm run release && npm run doc",
+    "release": "node release.mjs && npm run doc",
     "doc": "typedoc --out ./dist/docs ./src/index.ts"
   },
   "repository": {


### PR DESCRIPTION
## What happened:
Recursive git tag/git push tags. It was 'fun'.

## Why it happened:
When we run `npm publish`, we run `prepublishOnly`, which trigger `npm release`, which start `release.mjs`.
But this https://github.com/coveo/push-api-client.js/blob/484712d544d36104b5032b3d5d1bdd97dbfbe06e/release.mjs#L91  essentially do `npm publish`. Which start the loops again. And before we do a publish, well we do this
https://github.com/coveo/push-api-client.js/blob/484712d544d36104b5032b3d5d1bdd97dbfbe06e/release.mjs#L79-L88
So until we trip some recursion limit or whatever, well it keep on bump, commit, tag, and so forth.