### PR TITLE
chore: replace call by run

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,3 @@ jobs:
         run: npm run test
       - name: Build
         run: npm run build
-  CD:
-    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-    needs: CI
-    uses: ./.github/workflows/release.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,12 @@
 name: Create release
 on:
-  workflow_call:
+  workflow_run:
+    workflows:
+      - Build
+    types:
+      - completed
+    branches:
+      - main
 permissions:
   contents: write
   pages: write


### PR DESCRIPTION
There's either a documentation gap or a bug in GHA, I described the issue here
https://github.com/community/community/discussions/47583

So in the meantime, I'm reverting the changes and adding a branch filter based on:
https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#limiting-your-workflow-to-run-based-on-branches

Because it's hard to have certainty it won't trigger a resonance release cascade, I enabled the Required Reviewer Environment Protection Rule on CD for the time being.