### PR TITLE
fix(fetch): throw when request is nok

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "dayjs": "^1.10.4",
         "exponential-backoff": "^3.1.0",
         "fetch-undici-polyfill": "1.2.1",
+        "ts-dedent": "2.2.0",
         "zod": "^3.20.2"
       },
       "devDependencies": {
@@ -10478,6 +10479,14 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/ts-dedent": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.2.0.tgz",
+      "integrity": "sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==",
+      "engines": {
+        "node": ">=6.10"
       }
     },
     "node_modules/ts-jest": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "dayjs": "^1.10.4",
     "exponential-backoff": "^3.1.0",
     "fetch-undici-polyfill": "1.2.1",
+    "ts-dedent": "2.2.0",
     "zod": "^3.20.2"
   },
   "devDependencies": {

--- a/src/APICore.spec.ts
+++ b/src/APICore.spec.ts
@@ -63,7 +63,9 @@ describe('APICore', () => {
       await expect(apiCore.post('whatever')).rejects.toBe(fakeFetchError);
       expect(fetchMock).toBeCalledTimes(1);
       expect(mockedFetchErrorBuild).toBeCalledTimes(1);
-      expect(mockedFetchErrorBuild).toBeCalledWith(await fetchMock.mock.results[0].value);
+      expect(mockedFetchErrorBuild).toBeCalledWith(
+        await fetchMock.mock.results[0].value
+      );
     });
   });
 });

--- a/src/APICore.spec.ts
+++ b/src/APICore.spec.ts
@@ -1,0 +1,69 @@
+import type {Response} from 'undici';
+
+jest.mock('./errors/fetchError');
+import {FetchError} from './errors/fetchError';
+
+import {APICore} from './APICore';
+
+describe('APICore', () => {
+  const mockedFetchJson = jest.fn();
+  let fetchMock: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    fetchMock = jest.spyOn(global, 'fetch');
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockedFetchJson),
+    } as Response);
+  });
+
+  describe('when request is OK', () => {
+    it('resolve with json', async () => {
+      const apiCore = new APICore('suchsecret');
+      await expect(apiCore.post('whatever')).resolves.toBe(mockedFetchJson);
+    });
+  });
+
+  describe('when request is throttled', () => {
+    beforeEach(() => {
+      fetchMock.mockResolvedValueOnce({
+        ok: false,
+        status: 429,
+        json: () => Promise.resolve(mockedFetchJson),
+      });
+    });
+
+    it('try again and then resolve with json', async () => {
+      const apiCore = new APICore('suchsecret');
+      await expect(apiCore.post('whatever')).resolves.toBe(mockedFetchJson);
+      expect(fetchMock).toBeCalledTimes(2);
+    });
+  });
+
+  describe('when request is NOK and not throttled', () => {
+    let mockedFetchErrorBuild: jest.SpyInstance;
+    const fakeFetchError = jest.fn();
+
+    beforeEach(() => {
+      fetchMock.mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        json: () => Promise.resolve(mockedFetchJson),
+      });
+      mockedFetchErrorBuild = jest
+        .spyOn(FetchError, 'build')
+        .mockImplementationOnce(() =>
+          Promise.resolve(fakeFetchError as unknown as FetchError)
+        );
+    });
+
+    it('rejects a FetchError', async () => {
+      const apiCore = new APICore('suchsecret');
+      await expect(apiCore.post('whatever')).rejects.toBe(fakeFetchError);
+      expect(fetchMock).toBeCalledTimes(1);
+      expect(mockedFetchErrorBuild).toBeCalledTimes(1);
+      expect(mockedFetchErrorBuild).toBeCalledWith(await fetchMock.mock.results[0].value);
+    });
+  });
+});

--- a/src/errors/__snapshots__/fetchError.spec.ts.snap
+++ b/src/errors/__snapshots__/fetchError.spec.ts.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`FetchError when json returns a stringifiable object uses its stringify value in the message 1`] = `
+"Response body:
+{"hello":"world"}"
+`;
+
+exports[`FetchError when json returns a unstringifiable object uses the text value in the message 1`] = `
+"Response body:
+hello there"
+`;

--- a/src/errors/fetchError.spec.ts
+++ b/src/errors/fetchError.spec.ts
@@ -1,0 +1,63 @@
+import type {Response} from 'undici';
+import {PushApiClientBaseError} from './baseError';
+import {FetchError} from './fetchError';
+
+describe('FetchError', () => {
+  const fakeResponseJson = jest.fn();
+  const fakeResponseText = jest.fn();
+  const fakeResponse: Response = {
+    json: fakeResponseJson,
+    text: fakeResponseText,
+  } as unknown as Response;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    fakeResponseJson.mockResolvedValue(null);
+    fakeResponseText.mockResolvedValue('hello there');
+  });
+
+  it('has a proper name', async () => {
+    expect((await FetchError.build(fakeResponse)).name).toBe('Fetch Error');
+  });
+
+  it('inherit the PushApiClientBaseError', async () => {
+    expect(await FetchError.build(fakeResponse)).toBeInstanceOf(
+      PushApiClientBaseError
+    );
+  });
+
+  describe('when json returns a stringifiable object', () => {
+    beforeEach(() => {
+      fakeResponseJson.mockResolvedValueOnce({hello: 'world'});
+    });
+
+    it('uses its stringify value in the message', async () => {
+      expect((await FetchError.build(fakeResponse)).message).toMatchSnapshot();
+    });
+  });
+
+  describe('when json returns a unstringifiable object', () => {
+    beforeEach(() => {
+      const cyclicObject: {self?: object} = {};
+      cyclicObject.self = cyclicObject;
+      fakeResponseJson.mockResolvedValueOnce(cyclicObject);
+    });
+
+    it('uses the text value in the message', async () => {
+      expect((await FetchError.build(fakeResponse)).message).toMatchSnapshot();
+    });
+  });
+
+  describe('when json and text fails', () => {
+    beforeEach(() => {
+      fakeResponseJson.mockRejectedValueOnce('nope');
+      fakeResponseText.mockRejectedValueOnce('nope');
+    });
+
+    it('does not returns a FetchError', async () => {
+      await expect(FetchError.build(fakeResponse)).rejects.not.toBeInstanceOf(
+        FetchError
+      );
+    });
+  });
+});

--- a/src/errors/fetchError.ts
+++ b/src/errors/fetchError.ts
@@ -1,0 +1,23 @@
+import type {Response} from 'undici';
+import {PushApiClientBaseError} from './baseError';
+import dedent from 'ts-dedent';
+
+export class FetchError extends PushApiClientBaseError {
+  public name = 'Fetch Error';
+  public static async build(response: Response) {
+    let body: string;
+    try {
+      body = JSON.stringify(await response.json());
+    } catch (error) {
+      body = await response.text();
+    }
+    return new FetchError(body);
+  }
+  private constructor(public body: string) {
+    super();
+    this.message = dedent`
+      Response body:
+      ${body}
+    `;
+  }
+}

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -1,3 +1,5 @@
+export * from './fetchError'
 export * from './fieldErrors';
 export * from './privilegeError';
+export * from './throttleError';
 export * from './validatorErrors';

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -1,4 +1,4 @@
-export * from './fetchError'
+export * from './fetchError';
 export * from './fieldErrors';
 export * from './privilegeError';
 export * from './throttleError';

--- a/src/errors/throttleError.spec.ts
+++ b/src/errors/throttleError.spec.ts
@@ -1,0 +1,12 @@
+import {PushApiClientBaseError} from './baseError';
+import {ThrottleError} from './throttleError';
+
+describe('ThrottleError', () => {
+  it('has a proper name', () => {
+    expect(new ThrottleError().name).toBe('Throttle Error');
+  });
+
+  it('inherit the PushApiClientBaseError', () => {
+    expect(new ThrottleError()).toBeInstanceOf(PushApiClientBaseError);
+  });
+});

--- a/src/errors/throttleError.ts
+++ b/src/errors/throttleError.ts
@@ -1,0 +1,8 @@
+import {PushApiClientBaseError} from './baseError';
+
+export class ThrottleError extends PushApiClientBaseError {
+  public name = 'Throttle Error';
+  public constructor() {
+    super();
+  }
+}

--- a/src/errors/throttleError.ts
+++ b/src/errors/throttleError.ts
@@ -2,7 +2,4 @@ import {PushApiClientBaseError} from './baseError';
 
 export class ThrottleError extends PushApiClientBaseError {
   public name = 'Throttle Error';
-  public constructor() {
-    super();
-  }
 }


### PR DESCRIPTION
Handle this:
> The Promise returned from fetch() won't reject on HTTP error status even if the response is an HTTP 404 or 500. Instead, as soon as the server responds with headers, the Promise will resolve normally (with the [ok](https://developer.mozilla.org/en-US/docs/Web/API/Response/ok) property of the response set to false if the response isn't in the range 200–299), and it will only reject on network failure or if anything prevented the request from completing.

https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch

- Add FetchError
- Add ThrottleError
- Rework retry cb for exp-backoff