### PR TITLE
chore: include client details in header

### DIFF
--- a/src/APICore.ts
+++ b/src/APICore.ts
@@ -69,14 +69,17 @@ export class APICore {
   }
 
   private get requestHeaders(): Record<string, string> {
+    const {version} = require('../package.json');
+
     const authorizationHeader = {
       Authorization: `Bearer ${this.accessToken}`,
     };
 
     const documentsRequestHeaders = {
       ...authorizationHeader,
-      'Content-Type': 'application/json',
       Accept: 'application/json',
+      'Content-Type': 'application/json',
+      'User-Agent': `CoveoNodeJSSDK/${version}`,
     };
 
     return documentsRequestHeaders;

--- a/src/APICore.ts
+++ b/src/APICore.ts
@@ -79,7 +79,7 @@ export class APICore {
       ...authorizationHeader,
       Accept: 'application/json',
       'Content-Type': 'application/json',
-      'User-Agent': `CoveoNodeJSSDK/${version}`,
+      'User-Agent': `CoveoSDKNodeJS/${version}`,
     };
 
     return documentsRequestHeaders;


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-2802

This is a fairly quick one. Pascal Doyon requested that we include some basic client information in the 'User-Agent' request header, so now said header will include `CoveoNodeJSSDK/<VERSION>`.

https://docs.google.com/document/d/1FM3KDK8jlsGSz2IgtXLYfqz_xjvCFWXsSmHYlVf0rfs/edit

I was unable to get the current package version any way other than reading the package.json file through a `require`, which I'm not super happy about. It appears to be working as expected when running the tests, so I'll leave it unless anyone has any very strong opinions about it 😅 

Moreover, I couldn't find a good way to test that the version was correct unless I used the same "trick" within the test file, which I don't believe is particularly useful.