### PR TITLE
build(release): fix release workflow

### DIFF
--- a/release.mjs
+++ b/release.mjs
@@ -47,7 +47,7 @@ import {createActionAuth} from '@octokit/auth-action';
   // Passing an empty string allow empty commits (i.e. that does not modify any files) to be included.
   const commits = await getCommits('', lastTag);
   const parsedCommits = parseCommits(commits, CONVENTION.parserOpts);
-  const bumpInfo = CONVENTION.recommendedBumpOpts.whatBump(parsedCommits);
+  const bumpInfo = CONVENTION.whatBump(parsedCommits);
   const currentVersion = getCurrentVersion(PATH);
   const newVersion = getNextVersion(currentVersion, bumpInfo);
   const newVersionTag = `${VERSION_PREFIX}${newVersion}`;


### PR DESCRIPTION
The [create release workflow](https://github.com/coveo/push-api-client.js/actions/workflows/release.yml) is currently failing, which prevents [the node 22 support changes](https://github.com/coveo/push-api-client.js/commit/151d9c90965c9ec8751b19757c6bdfa4ce2f0eae) to come through.

![image](https://github.com/user-attachments/assets/93db2676-bfc7-42b0-8377-1bace72d921e)

If fails on the following [`TypeError: Cannot read properties of undefined (reading 'whatBump')`](https://github.com/coveo/push-api-client.js/actions/runs/11594306860/job/32280246725#step:10:117)

Looking at [`conventional-changelor-angular`'s source code](https://github.com/conventional-changelog/conventional-changelog/blob/master/packages/conventional-changelog-angular/src/index.js#L9), we can see that `whatBump` is exposed directly on the default export, and that `recommendedBumpOpts` does not exist anymore.